### PR TITLE
feat(apikey): add a way to copy apikey to clipboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,6 @@ node_modules/
 .tmp/
 /dist/
 target/
+.settings/
+.project
 *.iml

--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,8 @@
     "dragular": "~3.2.0",
     "angular-breadcrumb": "~0.4.1",
     "google-code-prettify": "~1.0.4",
-    "angular-schema-form": "~0.8.12"
+    "angular-schema-form": "~0.8.12",
+    "ngclipboard": "~1.0.0"
   },
   "resolutions": {
     "angular": "1.4.8"

--- a/bower_components/ngclipboard/.bower.json
+++ b/bower_components/ngclipboard/.bower.json
@@ -1,0 +1,34 @@
+{
+  "name": "ngclipboard",
+  "version": "1.0.0",
+  "homepage": "https://github.com/sachinchoolur/ngclipboard",
+  "authors": [
+    "Sachin N <sachi77n@gmail.com>"
+  ],
+  "description": "Angularjs directive for clipboard.js",
+  "main": "dist/ngclipboard.js",
+  "keywords": [
+    "ngclipboard",
+    "copy",
+    "cut",
+    "clipboard",
+    "angularjs"
+  ],
+  "dependencies": {
+    "clipboard": "^1.0.0",
+    "angular": ">=1.2.0"
+  },
+  "ignore": [
+    "README.md",
+    "demo"
+  ],
+  "_release": "1.0.0",
+  "_resolution": {
+    "type": "version",
+    "tag": "1.0.0",
+    "commit": "71b2dffc75dca4471b958c2ba19a93d59bea7124"
+  },
+  "_source": "https://github.com/sachinchoolur/ngclipboard.git",
+  "_target": "~1.0.0",
+  "_originalSource": "ngclipboard"
+}

--- a/bower_components/ngclipboard/.editorconfig
+++ b/bower_components/ngclipboard/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[package.json]
+indent_style = space
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false

--- a/bower_components/ngclipboard/.gitignore
+++ b/bower_components/ngclipboard/.gitignore
@@ -1,0 +1,2 @@
+/node_modules/
+/bower_components/

--- a/bower_components/ngclipboard/.jscsrc
+++ b/bower_components/ngclipboard/.jscsrc
@@ -1,0 +1,7 @@
+{
+  "preset": "airbnb",
+  "validateIndentation": 4,
+  "disallowTrailingComma": true,
+  "requireTrailingComma": false,
+  "excludeFiles": ["node_modules/**"]
+}

--- a/bower_components/ngclipboard/.jshintrc
+++ b/bower_components/ngclipboard/.jshintrc
@@ -1,0 +1,18 @@
+{
+    "node": true,
+    "browser": true,
+    "esnext": true,
+    "bitwise": true,
+    "camelcase": true,
+    "curly": true,
+    "eqeqeq": true,
+    "immed": true,
+    "indent": 2,
+    "latedef": true,
+    "newcap": true,
+    "noarg": true,
+    "quotmark": "single",
+    "undef": true,
+    "unused": true,
+    "strict": true
+}

--- a/bower_components/ngclipboard/.travis.yml
+++ b/bower_components/ngclipboard/.travis.yml
@@ -1,0 +1,6 @@
+language: node_js
+node_js:
+  - '0.10'
+before_script:
+  - 'npm install -g bower grunt-cli'
+  - 'bower install'

--- a/bower_components/ngclipboard/Gruntfile.js
+++ b/bower_components/ngclipboard/Gruntfile.js
@@ -1,0 +1,89 @@
+'use strict';
+module.exports = function(grunt) {
+    // Load all grunt tasks
+    require('load-grunt-tasks')(grunt);
+    // Show elapsed time at the end
+    require('time-grunt')(grunt);
+
+    // Project configuration.
+    grunt.initConfig({
+        // Metadata.
+        pkg: grunt.file.readJSON('package.json'),
+        banner: '/*! <%= pkg.name %> - v<%= pkg.version %> - ' +
+            '<%= grunt.template.today("yyyy-mm-dd") %>\n' +
+            '<%= pkg.homepage ? "* " + pkg.homepage + "\\n" : "" %>' +
+            '* Copyright (c) <%= grunt.template.today("yyyy") %> <%= pkg.author.name %>;' +
+            ' Licensed MIT */\n',
+        // Task configuration.
+        clean: {
+            files: ['dist']
+        },
+        concat: {
+            options: {
+                banner: '<%= banner %>',
+                stripBanners: true
+            },
+            dist: {
+                src: ['src/<%= pkg.name %>.js'],
+                dest: 'dist/<%= pkg.name %>.js'
+            }
+        },
+        uglify: {
+            options: {
+                banner: '<%= banner %>'
+            },
+            dist: {
+                src: '<%= concat.dist.dest %>',
+                dest: 'dist/<%= pkg.name %>.min.js'
+            }
+        },
+        jshint: {
+            options: {
+                reporter: require('jshint-stylish')
+            },
+            gruntfile: {
+                options: {
+                    jshintrc: '.jshintrc'
+                },
+                src: 'Gruntfile.js'
+            },
+            src: {
+                options: {
+                    jshintrc: 'src/.jshintrc'
+                },
+                src: ['src/**/*.js']
+            }
+        },
+        watch: {
+            gruntfile: {
+                files: '<%= jshint.gruntfile.src %>',
+                tasks: ['jshint:gruntfile']
+            },
+            src: {
+                files: '<%= jshint.src.src %>',
+                tasks: ['jshint:src']
+            },
+            test: {
+                files: '<%= jshint.test.src %>',
+                tasks: ['jshint:test']
+            }
+        },
+        connect: {
+            server: {
+                options: {
+                    hostname: '*',
+                    port: 9000
+                }
+            }
+        }
+    });
+
+    // Default task.
+    grunt.registerTask('default', ['jshint', 'connect', 'clean', 'concat', 'uglify']);
+    grunt.registerTask('server', function() {
+        grunt.log.warn('The `server` task has been deprecated. Use `grunt serve` to start a server.');
+        grunt.task.run(['serve']);
+    });
+    grunt.registerTask('serve', ['connect', 'watch']);
+    grunt.registerTask('test', ['jshint', 'connect']);
+};

--- a/bower_components/ngclipboard/LICENSE
+++ b/bower_components/ngclipboard/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Sachin N
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/bower_components/ngclipboard/bower.json
+++ b/bower_components/ngclipboard/bower.json
@@ -1,0 +1,25 @@
+{
+    "name": "ngclipboard",
+    "version": "1.0.0",
+    "homepage": "https://github.com/sachinchoolur/ngclipboard",
+    "authors": [
+        "Sachin N <sachi77n@gmail.com>"
+    ],
+    "description": "Angularjs directive for clipboard.js",
+    "main": "dist/ngclipboard.js",
+    "keywords": [
+        "ngclipboard",
+        "copy",
+        "cut",
+        "clipboard",
+        "angularjs"
+    ],
+    "dependencies": {
+        "clipboard": "^1.0.0",
+        "angular": ">=1.2.0"
+    },
+    "ignore": [
+        "README.md",
+        "demo"
+    ]
+}

--- a/bower_components/ngclipboard/contributing.md
+++ b/bower_components/ngclipboard/contributing.md
@@ -1,0 +1,32 @@
+# Contributing
+
+## Important notes
+Please don't edit files in the `dist` subdirectory as they are generated via Grunt. You'll find source code in the `src` subdirectory!
+
+### Code style
+Regarding code style like indentation and whitespace, **follow the conventions you see used in the source already.**
+
+### PhantomJS
+While Grunt can run the included unit tests via [PhantomJS](http://phantomjs.org/), this shouldn't be considered a substitute for the real thing. Please be sure to test the `test/*.html` unit test file(s) in _actual_ browsers.
+
+## Modifying the code
+First, ensure that you have the latest [Node.js](http://nodejs.org/) and [npm](http://npmjs.org/) installed.
+
+Test that Grunt's CLI and Bower are installed by running `grunt --version` and `bower --version`.  If the commands aren't found, run `npm install -g grunt-cli bower`.  For more information about installing the tools, see the [getting started with Grunt guide](http://gruntjs.com/getting-started) or [bower.io](http://bower.io/) respectively.
+
+1. Fork and clone the repo.
+1. Run `npm install` to install all build dependencies (including Grunt).
+1. Run `bower install` to install the front-end dependencies.
+1. Run `grunt` to grunt this project.
+
+Assuming that you don't see any red, you're ready to go. Just be sure to run `grunt` after making any changes, to ensure that nothing is broken.
+
+## Submitting pull requests
+
+1. Create a new branch, please don't work in your `master` branch directly.
+1. Add failing tests for the change you want to make. Run `grunt` to see the tests fail.
+1. Fix stuff.
+1. Run `grunt` to see if the tests pass. Repeat steps 2-4 until done.
+1. Open `test/*.html` unit test file(s) in actual browser to ensure tests pass everywhere.
+1. Update the documentation to reflect any changes.
+1. Push to your fork and submit a pull request.

--- a/bower_components/ngclipboard/dist/ngclipboard.js
+++ b/bower_components/ngclipboard/dist/ngclipboard.js
@@ -1,0 +1,40 @@
+/*! ngclipboard - v1.0.0 - 2015-10-21
+* https://github.com/sachinchoolur/ngclipboard
+* Copyright (c) 2015 Sachin; Licensed MIT */
+(function() {
+    'use strict';
+    angular.module('ngclipboard', []).directive('ngclipboard', function() {
+        return {
+            restrict: 'A',
+            scope: {
+                ngclipboardSuccess: '&',
+                ngclipboardError: '&'
+            },
+            link: function(scope, element) {
+
+                var _id = element.attr('id');
+                if (!_id) {
+                    element.attr('id', 'ngclipboard' + Date.now());
+                    _id = element.attr('id');
+                }
+
+                var clipboard = new Clipboard('#' + _id);
+
+                clipboard.on('success', function(e) {
+                    scope.ngclipboardSuccess({
+                        e: e,
+                        id: element.attr('id')
+                    });
+                });
+
+                clipboard.on('error', function(e) {
+                    scope.ngclipboardError({
+                        e: e,
+                        id: element.attr('id')
+                    });
+                });
+
+            }
+        };
+    });
+}());

--- a/bower_components/ngclipboard/dist/ngclipboard.min.js
+++ b/bower_components/ngclipboard/dist/ngclipboard.min.js
@@ -1,0 +1,4 @@
+/*! ngclipboard - v1.0.0 - 2015-10-21
+* https://github.com/sachinchoolur/ngclipboard
+* Copyright (c) 2015 Sachin; Licensed MIT */
+!function(){"use strict";angular.module("ngclipboard",[]).directive("ngclipboard",function(){return{restrict:"A",scope:{ngclipboardSuccess:"&",ngclipboardError:"&"},link:function(a,b){var c=b.attr("id");c||(b.attr("id","ngclipboard"+Date.now()),c=b.attr("id"));var d=new Clipboard("#"+c);d.on("success",function(c){a.ngclipboardSuccess({e:c,id:b.attr("id")})}),d.on("error",function(c){a.ngclipboardError({e:c,id:b.attr("id")})})}}})}();

--- a/bower_components/ngclipboard/package.json
+++ b/bower_components/ngclipboard/package.json
@@ -1,0 +1,44 @@
+{
+    "name": "ngclipboard",
+    "version": "1.0.0",
+    "description": "Angularjs directive for clipboard.js",
+    "keywords": [
+        "ngclipboard",
+        "copy",
+        "cut",
+        "clipboard",
+        "angularjs"
+    ],
+    "homepage": "https://github.com/sachinchoolur/ngclipboard",
+    "bugs": {
+        "url": "https://github.com/sachinchoolur/ngclipboard/issues",
+        "email": "sachi77n@gmail.com"
+    },
+    "author": {
+        "name": "Sachin",
+        "email": "sachi77n@gmail.com",
+        "url": "https://github.com/sachinchoolur"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git@github.com:sachinchoolur/ngclipboard.git"
+    },
+    "main": "dist/ngclipboard.js",
+    "license": "MIT",
+    "scripts": {
+        "test": "grunt"
+    },
+    "devDependencies": {
+        "grunt": "^0.4.5",
+        "grunt-contrib-clean": "^0.6.0",
+        "grunt-contrib-concat": "^0.5.0",
+        "grunt-contrib-connect": "^0.9.0",
+        "grunt-contrib-jshint": "^0.10.0",
+        "grunt-contrib-qunit": "^0.5.1",
+        "grunt-contrib-uglify": "^0.7.0",
+        "grunt-contrib-watch": "^0.6.1",
+        "jshint-stylish": "^1.0.0",
+        "load-grunt-tasks": "^2.0.0",
+        "time-grunt": "^1.0.0"
+    }
+}

--- a/bower_components/ngclipboard/src/.jshintrc
+++ b/bower_components/ngclipboard/src/.jshintrc
@@ -1,0 +1,18 @@
+{
+    "curly": true,
+    "eqeqeq": true,
+    "immed": true,
+    "latedef": true,
+    "newcap": true,
+    "noarg": true,
+    "sub": true,
+    "undef": true,
+    "unused": true,
+    "boss": true,
+    "eqnull": true,
+    "browser": true,
+    "predef": [
+        "angular",
+        "Clipboard"
+    ]
+}

--- a/bower_components/ngclipboard/src/ngclipboard.js
+++ b/bower_components/ngclipboard/src/ngclipboard.js
@@ -1,0 +1,37 @@
+(function() {
+    'use strict';
+    angular.module('ngclipboard', []).directive('ngclipboard', function() {
+        return {
+            restrict: 'A',
+            scope: {
+                ngclipboardSuccess: '&',
+                ngclipboardError: '&'
+            },
+            link: function(scope, element) {
+
+                var _id = element.attr('id');
+                if (!_id) {
+                    element.attr('id', 'ngclipboard' + Date.now());
+                    _id = element.attr('id');
+                }
+
+                var clipboard = new Clipboard('#' + _id);
+
+                clipboard.on('success', function(e) {
+                    scope.ngclipboardSuccess({
+                        e: e,
+                        id: element.attr('id')
+                    });
+                });
+
+                clipboard.on('error', function(e) {
+                    scope.ngclipboardError({
+                        e: e,
+                        id: element.attr('id')
+                    });
+                });
+
+            }
+        };
+    });
+}());

--- a/src/app/api/admin/apikeys/apikeys.controller.js
+++ b/src/app/api/admin/apikeys/apikeys.controller.js
@@ -26,6 +26,7 @@ class ApiKeysController {
     this.apiKeys = resolvedApiKeys.data;
 
     this.showRevokedKeys = false;
+    this.msg ="copy to clipboard";
 	}
 
   hasKeysDefined() {

--- a/src/app/api/admin/apikeys/apikeys.html
+++ b/src/app/api/admin/apikeys/apikeys.html
@@ -34,11 +34,15 @@
         <tr style="background-color: #9fb9be;">
           <td colspan="4" style="font-weight: bold">{{value.name}} ({{value.keys.length}} keys)</td>
         </tr>
-				<tr ng-repeat="apikey in value.keys | filter: apiKeysCtrl.showRevokedKeys">
+				<tr ng-repeat="apikey in value.keys | filter: apiKeysCtrl.showRevokedKeys" ng-mouseover="hovered = true"  ng-mouseout="hovered = false">
           <td>
             <ng-md-icon ng-show="!apikey.revoked" icon="done" style="fill: #107F20"></ng-md-icon>
             <ng-md-icon ng-show="apikey.revoked" icon="clear" style="fill: #BE2628"></ng-md-icon>
             <code>{{apikey.key}}</code>
+            <span>
+             	<md-tooltip md-direction="right">Copy to clipboard</md-tooltip>
+              <ng-md-icon ng-show="hovered" ng-hide="!hovered" icon="link" ngclipboard data-clipboard-text="{{apikey.key}}" role="button" ></ng-md-icon>
+             </span>
           </td>
           <td>{{apikey.revoked_at | date:'yyyy-MM-dd HH:mm:ss'}}</td>
           <td>{{apikey.expire_on | date:'yyyy-MM-dd HH:mm:ss'}}</td>

--- a/src/app/index.module.js
+++ b/src/app/index.module.js
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -68,7 +68,7 @@ import DialogLoginController from './login/dialog/loginDialog.controller';
 
 angular.module('gravitee', ['ui.router', 'ngMaterial', 'ramlConsoleApp', 'btford.markdown', 'swaggerUi',
     'ngMdIcons', 'ui.codemirror', 'md.data.table', 'highcharts-ng', 'ngCookies', 'dragularModule', 'readMore',
-    'ncy-angular-breadcrumb', 'schemaForm'])
+    angularDragula(angular), 'ncy-angular-breadcrumb', 'schemaForm', 'ngclipboard'])
   .constant('baseURL', '/management/')
   .config(config)
   .config(routerConfig)


### PR DESCRIPTION
This feature allow user to directly copy the api-key to clipboard.
It add an anchor like right after the api-key to allow copy
- use of ngclipboard library (without flash)

Closes #10