### PR TITLE
feat(apikey): add a way to copy apikey to clipboard

### DIFF
--- a/src/app/api/admin/apikeys/apikeys.controller.js
+++ b/src/app/api/admin/apikeys/apikeys.controller.js
@@ -26,7 +26,6 @@ class ApiKeysController {
     this.apiKeys = resolvedApiKeys.data;
 
     this.showRevokedKeys = false;
-    this.msg ="copy to clipboard";
 	}
 
   hasKeysDefined() {

--- a/src/app/application/details/apikeys/applicationAPIKeys.html
+++ b/src/app/application/details/apikeys/applicationAPIKeys.html
@@ -38,11 +38,15 @@
             <ng-md-icon ng-if="applicationCtrl.isOwner()" icon="autorenew" ng-click="applicationAPIKeysCtrl.generateAPIKey(applicationCtrl.application, api)"></ng-md-icon>
           </td>
         </tr>
-		<tr ng-repeat="apikey in value.keys | filter: applicationAPIKeysCtrl.showRevokedKeys">
+		<tr ng-repeat="apikey in value.keys | filter: applicationAPIKeysCtrl.showRevokedKeys"  ng-mouseover="hovered = true"  ng-mouseout="hovered = false">
           <td>
             <ng-md-icon ng-show="!apikey.revoked" icon="done" style="fill: #107F20"></ng-md-icon>
             <ng-md-icon ng-show="apikey.revoked" icon="clear" style="fill: #BE2628"></ng-md-icon>
             <code>{{apikey.key}}</code>
+             <span>
+             	<md-tooltip md-direction="right">Copy to clipboard</md-tooltip>
+              <ng-md-icon ng-show="hovered" ng-hide="!hovered" icon="link" ngclipboard data-clipboard-text="{{apikey.key}}" role="button" ></ng-md-icon>
+             </span>
           </td>
           <td>{{apikey.revoked_at | date:'yyyy-MM-dd HH:mm:ss'}}</td>
           <td>{{apikey.expire_on | date:'yyyy-MM-dd HH:mm:ss'}}</td>


### PR DESCRIPTION
This feature allow user to directly copy the api-key to clipboard from his
application page.
It add an anchor like right after the api-key to allow copy
- use of ngclipboard library (without flash)

Closes #13