### PR TITLE
fix: resources must have an icon on instances page

### DIFF
--- a/src/app/instances/details/environment/instanceEnvironment.html
+++ b/src/app/instances/details/environment/instanceEnvironment.html
@@ -86,6 +86,7 @@
             <ng-md-icon ng-switch-when="service" icon="layers"></ng-md-icon>
             <ng-md-icon ng-switch-when="repository" icon="folder_open"></ng-md-icon>
             <ng-md-icon ng-switch-when="reporter" icon="dashboard"></ng-md-icon>
+            <ng-md-icon ng-switch-when="resource" icon="style"></ng-md-icon>
           </td>
           <td md-cell>{{plugin.id}}</td>
           <td md-cell>{{plugin.name}}</td>


### PR DESCRIPTION
fix gravitee-io/issues#265