### PR TITLE
fix: wrong version number in the ui

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,10 @@
                                     <value>"version": "${project.version}"</value>
                                 </replacement>
                                 <replacement>
+                                    <token>'version': '(.*)'</token>
+                                    <value>'version': '${project.version}'</value>
+                                </replacement>
+                                <replacement>
                                     <token>"description"(\s*):(\s*)"(.*)"</token>
                                     <value>"description": "${project.name}"</value>
                                 </replacement>


### PR DESCRIPTION
the version number replacement does not work for constants.js

fix gravitee-io/issues#282