### PR TITLE
feat(gateway): HTTP Compression is enabled by default at the client side

### DIFF
--- a/src/app/api/admin/endpoint/endpointConfiguration.controller.js
+++ b/src/app/api/admin/endpoint/endpointConfiguration.controller.js
@@ -41,7 +41,7 @@ class ApiEndpointController {
           readTimeout : 10000,
           pipelining : false,
           maxConcurrentConnections : 100,
-          useCompression : false
+          useCompression : true
         }
       };
 


### PR DESCRIPTION
Closes gravitee-io/issues#343