### PR TITLE
fix(api): Refresh API when switching to an other screen

### DIFF
--- a/src/components/sidenav/submenu.html
+++ b/src/components/sidenav/submenu.html
@@ -24,6 +24,7 @@
 <md-list-item ng-repeat="menuItem in $ctrl.submenuItems track by menuItem.name">
   <a
     ui-sref="{{ :: menuItem.name }}"
+    ui-sref-opts="{reload: true}"
     ui-sref-active="sidenav-active"
     title="{{ :: menuItem.data.menu.label }}">
     <ng-md-icon icon="{{ :: menuItem.data.menu.icon }}"></ng-md-icon>


### PR DESCRIPTION
Closes gravitee-io/issues#519