### PR TITLE
fix(policies): d&d policies on paths with regex

### DIFF
--- a/src/management/api/policies/policies.controller.ts
+++ b/src/management/api/policies/policies.controller.ts
@@ -35,7 +35,8 @@ class ApiPoliciesController {
     private dragularService,
     private $q,
     private $rootScope,
-    private $timeout
+    private $timeout,
+    private StringService
   ) {
     'ngInject';
     this.apiPoliciesByPath = {};
@@ -122,7 +123,7 @@ class ApiPoliciesController {
   }
 
   initDragularDropZone(path) {
-    const dragularApiOptions = document.querySelector('.dropzone-' + _.kebabCase(path));
+    const dragularApiOptions = document.querySelector('.dropzone-' + this.StringService.hashCode(path));
     if (dragularApiOptions) {
       this.dragularService([dragularApiOptions], {
         copy: false,
@@ -221,7 +222,7 @@ class ApiPoliciesController {
   getDropzoneClass(path) {
     return "gravitee-policy-dropzone " +
       'gravitee-policy-dropzone-filled' +
-      " dropzone-" + _.kebabCase(path);
+      " dropzone-" + this.StringService.hashCode(path);
   }
 
   toggleHttpMethod(method, methods) {

--- a/src/management/management.module.ts
+++ b/src/management/management.module.ts
@@ -268,6 +268,8 @@ import PageRamlComponent from '../components/documentation/page-raml.component';
 import PageMarkdownComponent from '../components/documentation/page-markdown.component';
 import PageSidenavDirective from '../components/documentation/page-sidenav.directive';
 
+import StringService from '../services/string.service';
+
 import config from './management.config';
 import routerConfig from '../index.route';
 import managementRouterConfig from './management.route';
@@ -379,6 +381,7 @@ angular.module('gravitee-management', ['ui.router', 'ngMaterial', 'ramlConsoleAp
   .service('TagService', TagService)
   .service('TenantService', TenantService)
   .service('PortalPagesService', PortalPagesService)
+  .service('StringService', StringService)
   .directive('filecontent', () => DocumentationDirective)
   .directive('noDirtyCheck', () => new FormDirective())
   .directive('autofocus', () => new AutofocusDirective())

--- a/src/services/string.service.ts
+++ b/src/services/string.service.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+class StringService {
+
+  constructor() {
+    'ngInject';
+  }
+
+  hashCode(str) {
+    let hash = 0;
+    if (str.length == 0) return hash;
+    for ( let i = 0; i < str.length; i++) {
+      let char = str.charCodeAt(i);
+      hash = ((hash<<5)-hash)+char;
+      hash = hash & hash; // Convert to 32bit integer
+    }
+    return hash;
+  }
+
+}
+
+export default StringService;


### PR DESCRIPTION
because _.kebabCase() remove special characters, _.kebabCase(/foo/.*)
and _.kebabCase(/foo) are the same. And Dragular doesn't appreciate it.

fix gravitee-io/issues#560