### PR TITLE
fix(portal): Use browser timezone to display charts

### DIFF
--- a/src/components/chart/chart.directive.ts
+++ b/src/components/chart/chart.directive.ts
@@ -33,6 +33,13 @@ class ChartDirective {
       },
       controller: ChartController,
       link: function (scope, element, attributes, controller) {
+
+        Highcharts.setOptions({
+          global: {
+            useUTC: false
+          }
+        });
+
         let chartElement = element[0];
 
         if (scope.type && scope.type.startsWith('area')) {


### PR DESCRIPTION
Closes gravitee-io/issues#587