### PR TITLE
fix(portal): Remove call to retrieve metadata from API homepage

### DIFF
--- a/src/portal/portal.route.ts
+++ b/src/portal/portal.route.ts
@@ -88,9 +88,7 @@ function portalRouterConfig($stateProvider: ng.ui.IStateProvider) {
       url: '/apis/:apiId',
       resolve: {
         api: ($stateParams: ng.ui.IStateParamsService, ApiService: ApiService) =>
-          ApiService.get($stateParams['apiId']).then(response => response.data),
-        metadata: ($stateParams: ng.ui.IStateParamsService, ApiService: ApiService) =>
-          ApiService.listApiMetadata($stateParams['apiId']).then(response => response.data)
+          ApiService.get($stateParams['apiId']).then(response => response.data)
       },
       component: 'api'
     })


### PR DESCRIPTION
Closes gravitee-io/issues#603