### PR TITLE
fix: tenants needed on the general page

### DIFF
--- a/src/management/api/apis.route.ts
+++ b/src/management/api/apis.route.ts
@@ -54,6 +54,7 @@ function apisRouterConfig($stateProvider: ng.ui.IStateProvider) {
             return response.data;
           });
         },
+        resolvedTenants: () => [],
         onEnter: function (UserService, ApiService, $stateParams) {
           if (!UserService.currentUser.userApiPermissions) {
             UserService.currentUser.userApiPermissions = [];


### PR DESCRIPTION
Because it's the same controller for general and gateway pages, we have to create a fake `resolvedTenants` object