### PR TITLE
Fix an issue with oauth2 redirect_uri

### DIFF
--- a/src/authentication/authentication.config.ts
+++ b/src/authentication/authentication.config.ts
@@ -48,7 +48,7 @@ function authenticationConfig ($authProvider: AuthProvider, Constants) {
       $authProvider.oauth2(_.merge(customConfig, {
         url: Constants.baseURL + 'auth/oauth2',
         oauthType: '2.0',
-        redirectUri: window.location.origin,
+        redirectUri: window.location.origin + window.location.pathname,
         requiredUrlParams: ['scope'],
         scopeDelimiter: ' '
       }));

--- a/src/authentication/authentication.config.ts
+++ b/src/authentication/authentication.config.ts
@@ -48,7 +48,7 @@ function authenticationConfig ($authProvider: AuthProvider, Constants) {
       $authProvider.oauth2(_.merge(customConfig, {
         url: Constants.baseURL + 'auth/oauth2',
         oauthType: '2.0',
-        redirectUri: window.location.origin + window.location.pathname,
+        redirectUri: window.location.origin + (window.location.pathname == '/' ? '' : window.location.pathname),
         requiredUrlParams: ['scope'],
         scopeDelimiter: ' '
       }));


### PR DESCRIPTION
Fixes the `redirect_uri` sent to an oauth2 authentication endpoint when
the application is hosted with some path prefix. The path prefix should
now be included in the redirect_uri.

Fixes issue #854