### PR TITLE
fix: hide scrollbar of contextual documentation

### DIFF
--- a/src/components/contextual/_contextual-doc.component.scss
+++ b/src/components/contextual/_contextual-doc.component.scss
@@ -41,5 +41,8 @@
   ol,li {
     list-style: inherit;
   }
+  ::-webkit-scrollbar {
+    display: none;
+  }
 }
 


### PR DESCRIPTION
This closes gravitee-io/issues#1120