### PR TITLE
fix: Plan preview is not correctly displayed on low resolution

### DIFF
--- a/src/management/api/api-plan.html
+++ b/src/management/api/api-plan.html
@@ -15,7 +15,7 @@
     limitations under the License.
 
 -->
-<md-card class="gravitee-card gravitee-plan-box" style="width: 350px;margin: 0 auto;">
+<md-card class="gravitee-card gravitee-plan-box" style="max-width: 350px;margin: 0 auto;">
   <md-card-header>
     <h3 layout-padding>{{$ctrl.plan.name}}</h3>
   </md-card-header>


### PR DESCRIPTION
This closes gravitee-io/issues#1221