### PR TITLE
Propsal : add eureka support to Webui

### DIFF
--- a/src/management/api/proxy/apiProxy.controller.ts
+++ b/src/management/api/proxy/apiProxy.controller.ts
@@ -69,6 +69,8 @@ class ApiProxyController {
 
     this.api.labels = this.api.labels || [];
 
+    this.$scope.discoveryProvider = ['CONSUL', 'EUREKA'];
+
     this.$scope.lbs = [
       {
         name: 'Round-Robin',
@@ -250,6 +252,10 @@ class ApiProxyController {
     this.SidenavService.setCurrentResource(this.api.name);
   }
 
+  onDiscoveryProviderChange() {
+    delete this.discovery.configuration;
+  }
+
   update(api) {
     if (!this.failoverEnabled) {
       delete api.proxy.failover;
@@ -257,9 +263,6 @@ class ApiProxyController {
     // Discovery is disabled, set dummy values
     if (this.discovery.enabled === false) {
       delete this.discovery.configuration;
-    } else {
-      // Set default provider
-      this.discovery.provider = 'CONSUL';
     }
     this.api.services['discovery'] = this.discovery;
 

--- a/src/management/api/proxy/backend/endpoint/apiEndpoints.html
+++ b/src/management/api/proxy/backend/endpoint/apiEndpoints.html
@@ -86,33 +86,57 @@
     <br>
 
     <div ng-show="apiProxyCtrl.discovery.enabled">
-      <md-subheader class="md-primary" style="background-color: #fafafa">Consul.io configuration</md-subheader>
-      <md-content layout="column">
-        <md-input-container>
-          <label>HTTP Endpoint</label>
-          <input ng-model="apiProxyCtrl.discovery.configuration.url" autofocus type="url" required placeholder="http://localhost:8500">
-          <div class="hint">Address of the Consul agent with the port.</div>
-        </md-input-container>
+      <div layout="column" layout-wrap layout-gt-sm="row">
+        <div flex-xs flex="50">
+          <md-input-container class="md-block" flex-gt-sm>
+            <label>Service discovery provider</label>
+            <md-select ng-model="apiProxyCtrl.discovery.provider" ng-change="apiProxyCtrl.onDiscoveryProviderChange()" ng-required="apiProxyCtrl.discovery.enabled" ng-disabled="!apiProxyCtrl.discovery.enabled">
+              <md-option ng-repeat="provider in discoveryProvider" value="{{provider}}">
+                {{provider}}
+              </md-option>
+            </md-select>
+          </md-input-container>
+        </div>
+      </div>
+      <div ng-if="apiProxyCtrl.discovery.provider === 'CONSUL'">
+        <md-subheader class="md-primary" style="background-color: #fafafa">Consul.io configuration</md-subheader>
+        <md-content layout="column">
+          <md-input-container>
+            <label>HTTP Endpoint</label>
+            <input ng-model="apiProxyCtrl.discovery.configuration.url" autofocus type="url" required placeholder="http://localhost:8500">
+            <div class="hint">Address of the Consul agent with the port.</div>
+          </md-input-container>
 
-        <md-input-container>
-          <label>Service</label>
-          <input ng-model="apiProxyCtrl.discovery.configuration.service" type="text" required placeholder="my-service-name">
-          <div class="hint">The service name to query</div>
-        </md-input-container>
+          <md-input-container>
+            <label>Service</label>
+            <input ng-model="apiProxyCtrl.discovery.configuration.service" type="text" required placeholder="my-service-name">
+            <div class="hint">The service name to query</div>
+          </md-input-container>
 
-        <md-input-container>
-          <label>ACL</label>
-          <input ng-model="apiProxyCtrl.discovery.configuration.acl" type="text">
-          <div class="hint">ACL token to use in the request. This can also be specified via the CONSUL_HTTP_TOKEN environment variable.
-            If unspecified, the query will default to the token of the Consul agent at the HTTP address.</div>
-        </md-input-container>
+          <md-input-container>
+            <label>ACL</label>
+            <input ng-model="apiProxyCtrl.discovery.configuration.acl" type="text">
+            <div class="hint">ACL token to use in the request. This can also be specified via the CONSUL_HTTP_TOKEN environment variable.
+              If unspecified, the query will default to the token of the Consul agent at the HTTP address.</div>
+          </md-input-container>
 
-        <md-input-container>
-          <label>DC</label>
-          <input ng-model="apiProxyCtrl.discovery.configuration.dc" type="text">
-          <div class="hint">Name of the data-center to query. If unspecified, the query will default to the data-center of the Consul agent at the HTTP address.</div>
-        </md-input-container>
-      </md-content>
+          <md-input-container>
+            <label>DC</label>
+            <input ng-model="apiProxyCtrl.discovery.configuration.dc" type="text">
+            <div class="hint">Name of the data-center to query. If unspecified, the query will default to the data-center of the Consul agent at the HTTP address.</div>
+          </md-input-container>
+        </md-content>
+      </div>
+      <div ng-if="apiProxyCtrl.discovery.provider === 'EUREKA'">
+        <md-subheader class="md-primary" style="background-color: #fafafa">Eureka configuration (Beta feature)</md-subheader>
+        <md-content layout="column">
+          <md-input-container>
+            <label>Service</label>
+            <input ng-model="apiProxyCtrl.discovery.configuration.service" type="text" required placeholder="my-service-name">
+            <div class="hint">The service name to query</div>
+          </md-input-container>
+        </md-content>
+      </div>
     </div>
 
   <div class="md-actions gravitee-api-save-button" layout="row">


### PR DESCRIPTION
It is a proposal , the eureka service discovery needs some improvements in the UI but as discussed with david brassely this plugin must be optional and will not be packaged into the core plateform. Currently I expect a solution to have a different UI when the plugin is present or not (Property in constants.json ?)


* https://github.com/gravitee-io/issues/issues/1311
* https://github.com/gravitee-io/issues/issues/1310