### PR TITLE
fix: When writing first API page and refreshing the browser, the page…

### DIFF
--- a/src/management/api/portal/apis.portal.route.ts
+++ b/src/management/api/portal/apis.portal.route.ts
@@ -242,7 +242,7 @@ function apisPortalRouterConfig($stateProvider) {
       }
     })
     .state('management.apis.detail.portal.documentation.new', {
-      url: '/new',
+      url: '/new?:type',
       template: require('./documentation/pages/page/apiPage.html'),
       controller: 'PageController',
       controllerAs: 'pageCtrl',

--- a/src/management/configuration/configuration.route.ts
+++ b/src/management/configuration/configuration.route.ts
@@ -202,7 +202,7 @@ function configurationRouterConfig($stateProvider) {
       }
     })
     .state('management.settings.pages.new', {
-      url: '/new',
+      url: '/new?:type',
       template: require('./pages/page/page.html'),
       controller: 'NewPageController',
       controllerAs: 'pageCtrl',


### PR DESCRIPTION
… type is lost and it's impossible to save

This closes gravitee-io/issues#1374