### PR TITLE
fix: Calendar widget is displayed wrong week days on analytics filters

### DIFF
--- a/src/components/dashboard/dashboard-timeframe.html
+++ b/src/components/dashboard/dashboard-timeframe.html
@@ -56,7 +56,7 @@
         <md-input-container style="margin-bottom: 0;">
           <label>from</label>
           <input moment-picker="$ctrl.pickerStartDateFormated"
-                 locale="en"
+                 locale="en-gb"
                  format="YYYY-MM-DD HH:mm"
                  max-date="$ctrl.pickerEndDate"
                  ng-model="$ctrl.pickerStartDate"
@@ -65,7 +65,7 @@
         <md-input-container style="margin-bottom: 0;">
           <label>to</label>
           <input moment-picker="$ctrl.pickerEndDateFormated"
-                 locale="en"
+                 locale="en-gb"
                  format="YYYY-MM-DD HH:mm"
                  min-date="$ctrl.pickerStartDate"
                  max-date="$ctrl.now"

--- a/src/components/logs/logs-timeframe.html
+++ b/src/components/logs/logs-timeframe.html
@@ -28,7 +28,7 @@
     <md-input-container style="margin-bottom: 0;">
       <label>from</label>
       <input moment-picker="$ctrl.pickerStartDateFormated"
-             locale="en"
+             locale="en-gb"
              format="YYYY-MM-DD HH:mm"
              max-date="$ctrl.pickerEndDate"
              ng-model="$ctrl.pickerStartDate"
@@ -37,7 +37,7 @@
     <md-input-container style="margin-bottom: 0;">
       <label>to</label>
       <input moment-picker="$ctrl.pickerEndDateFormated"
-             locale="en"
+             locale="en-gb"
              format="YYYY-MM-DD HH:mm"
              min-date="$ctrl.pickerStartDate"
              max-date="$ctrl.now"

--- a/src/management/api/analytics/logs/configure-logging-editor.dialog.html
+++ b/src/management/api/analytics/logs/configure-logging-editor.dialog.html
@@ -102,7 +102,7 @@
                 <md-input-container style="margin-bottom: 0;">
                   <span>Logging is ended at: </span>
                   <input moment-picker="pickerStartDateFormated"
-                         locale="en"
+                         locale="en-gb"
                          format="YYYY-MM-DD HH:mm"
                          ng-model="condition.param1"
                          ng-model-options="{ updateOn: 'blur' }">


### PR DESCRIPTION
This closes gravitee-io/issues#1684