### PR TITLE
fix(audit): Sharding tags must be part of API definition

### DIFF
--- a/src/management/api/audit/history/apiHistory.controller.ts
+++ b/src/management/api/audit/history/apiHistory.controller.ts
@@ -280,7 +280,6 @@ class ApiHistoryController {
     delete api.picture_url;
     delete api.views;
     delete api.groups;
-    delete api.tags;
     delete api.etag;
     delete api.context_path;
   }


### PR DESCRIPTION
Closes gravitee-io/issues#1774