### PR TITLE
fix: Dashboard analytics is not allowing to set multiple filters

### DIFF
--- a/src/management/management.route.ts
+++ b/src/management/management.route.ts
@@ -123,6 +123,10 @@ function managementRouterConfig($stateProvider) {
         to: {
           type: 'int',
           dynamic: true
+        },
+        q: {
+          type: 'string',
+          dynamic: true
         }
       }
     })


### PR DESCRIPTION
This closes gravitee-io/issues#1780