### PR TITLE
fix(metadata): global empty date metadata cannot be overriden

### DIFF
--- a/src/management/api/portal/documentation/metadata/dialog/update.api.metadata.dialog.controller.ts
+++ b/src/management/api/portal/documentation/metadata/dialog/update.api.metadata.dialog.controller.ts
@@ -22,7 +22,9 @@ function UpdateApiMetadataDialogController(ApiService: ApiService, $mdDialog: an
   this.metadata = apiMetadata;
   if ('date' === this.metadata.format) {
     this.metadata.value = this.metadata.value ? new Date(this.metadata.value) : null;
-    this.metadata.defaultValue = new Date(this.metadata.defaultValue);
+    if (this.metadata.defaultValue) {
+      this.metadata.defaultValue = new Date(this.metadata.defaultValue);
+    }
   }
   this.metadataFormats = metadataFormats;
 


### PR DESCRIPTION
fix gravitee-io/issues#1869