### PR TITLE
configurable timeout for the analytics repository client

### DIFF
--- a/constants.json
+++ b/constants.json
@@ -1,3 +1,4 @@
 {
-  "baseURL": "/management/"
+  "baseURL": "/management/",
+  "analyticsHttpTimeout": 30000
 }

--- a/constants.tpl.json
+++ b/constants.tpl.json
@@ -1,3 +1,4 @@
 {
-  "baseURL": "/management/"
+  "baseURL": "/management/",
+  "analyticsHttpTimeout": 30000
 }

--- a/src/services/analytics.service.ts
+++ b/src/services/analytics.service.ts
@@ -18,10 +18,16 @@ import * as _ from 'lodash';
 
 class AnalyticsService {
   private analyticsURL: string;
+  private analyticsHttpTimeout: number;
 
   constructor(private $http, Constants) {
     'ngInject';
     this.analyticsURL = `${Constants.baseURL}platform/analytics`;
+
+    if(Constants.analyticsHttpTimeout)
+      this.analyticsHttpTimeout = Constants.analyticsHttpTimeout as number
+    else
+      this.analyticsHttpTimeout = 30000
   }
 
   /*
@@ -38,7 +44,8 @@ class AnalyticsService {
       }
     });
 
-    return this.$http.get(url, {timeout: 30000});
+
+    return this.$http.get(url, {timeout: this.analyticsHttpTimeout});
   }
 }
 

--- a/src/services/api.service.ts
+++ b/src/services/api.service.ts
@@ -33,11 +33,17 @@ interface IMembership {
 class ApiService {
   private apisURL: string;
   private Constants: any;
+  private analyticsHttpTimeout: number;
 
   constructor(private $http, Constants) {
     'ngInject';
     this.apisURL = `${Constants.baseURL}apis/`;
     this.Constants = Constants;
+
+    if(Constants.analyticsHttpTimeout)
+      this.analyticsHttpTimeout = Constants.analyticsHttpTimeout as number
+    else
+      this.analyticsHttpTimeout = 30000
   }
 
   defaultHttpHeaders(): string[] {
@@ -159,7 +165,7 @@ class ApiService {
       }
     });
 
-    return this.$http.get(url, {timeout: 30000});
+    return this.$http.get(url, {timeout: this.analyticsHttpTimeout});
   }
 
   /*

--- a/src/services/application.service.ts
+++ b/src/services/application.service.ts
@@ -39,10 +39,16 @@ interface IMembership {
 
 class ApplicationService {
   private applicationsURL: string;
+  private analyticsHttpTimeout: number;
 
   constructor(private $http: ng.IHttpService, Constants) {
     'ngInject';
     this.applicationsURL = `${Constants.baseURL}applications/`;
+
+    if(Constants.analyticsHttpTimeout)
+      this.analyticsHttpTimeout = Constants.analyticsHttpTimeout as number
+    else
+      this.analyticsHttpTimeout = 30000
   }
 
   private subscriptionsURL(applicationId: string): string {
@@ -162,7 +168,7 @@ class ApplicationService {
       }
     });
 
-    return this.$http.get(url, {timeout: 30000});
+    return this.$http.get(url, {timeout: this.analyticsHttpTimeout});
   }
 
   /*


### PR DESCRIPTION
configurable timeout to handle long running elasticsearch queries in case of a large time window or many statistics data

fix gravitee-io/issues#1920