### PR TITLE
fix oauth2RedirectUrl

### DIFF
--- a/src/components/documentation/page/page-swagger.component.ts
+++ b/src/components/documentation/page/page-swagger.component.ts
@@ -78,6 +78,7 @@ const PageSwaggerComponent: ng.IComponentOptions = {
           return req;
         },
         spec: contentAsJson,
+        oauth2RedirectUrl: window.location.origin + window.location.pathname + (window.location.pathname.substr(-1) != '/' ? '/' : '') + 'swagger-oauth2-redirect.html',
       };
 
       if (!_.isNil(this.page.configuration)) {
@@ -100,7 +101,6 @@ const PageSwaggerComponent: ng.IComponentOptions = {
         cfg["showCommonExtensions"] =
           _.isNil(this.page.configuration.showCommonExtensions)
             ? false : this.page.configuration.showCommonExtensions === "true";
-        cfg["oauth2RedirectUrl"] = window.location.origin + '/swagger-oauth2-redirect.html';
         cfg["maxDisplayedTags"] =
           _.isNaN(Number(this.page.configuration.maxDisplayedTags)) || this.page.configuration.maxDisplayedTags === "-1"
             ? undefined : Number(this.page.configuration.maxDisplayedTags);


### PR DESCRIPTION
- Set oauth2RedirectUrl even if there is no configuration page saved
- Add pathname in oauth2RedirectUrl to fix the url when gravitee management ui is not hosted on root path

Fixes https://github.com/gravitee-io/issues/issues/2011