### PR TITLE
fix():  use query parameter to build a status filter in api analytics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ npm-debug.log
 /node/
 /target/
 .DS_Store
+.project
+.settings

--- a/src/components/dashboard/dashboard-filter.controller.ts
+++ b/src/components/dashboard/dashboard-filter.controller.ts
@@ -38,6 +38,34 @@ class DashboardFilterController {
     });
   }
 
+  $onInit() {
+    //init filters based on stateParams
+    let q = this.$state.params["q"];
+    if (q) {
+      this.decodeQueryFilters(q);
+    } else {
+      this.onFilterChange({query: undefined, widget: this.lastSource});
+    }
+  }
+
+  private decodeQueryFilters(query) {
+    let filters = query.split("AND");
+    for (let i = 0; i < filters.length; i++) {
+      let queryFilter = filters[i].replace(/[()]/g, "");
+      let kv = queryFilter.split(":");
+      let k = kv[0].trim();
+      let v = kv[1].replace(/[\\\"]/g, "").split('OR').map(x => x.trim());
+      
+      let filter: any = {};
+      filter.key = v;
+      filter.name = v
+      filter.field = k;
+      filter.fieldLabel = k;
+
+      this.addFieldFilter(filter);
+    }
+  }
+
   addFieldFilter(filter) {
     let field = this.fields[filter.field] || {filters: {}};
 
@@ -49,7 +77,7 @@ class DashboardFilterController {
     let label = (filter.fieldLabel ? filter.fieldLabel : filter.field)
       + " = '" + filter.name + "'";
 
-    let query = '(' + filter.field + ":" + _.map(_.keys(field.filters), (key) => "\\\"" + key + "\\\"").join(' OR ') + ')';
+    let query = '(' + filter.field + ":" + _.map(_.keys(field.filters), (key) => key.includes('TO')?key:"\\\"" + key + "\\\"").join(' OR ') + ')';
 
     this.filters.push({
       source: filter.widget,
@@ -101,7 +129,7 @@ class DashboardFilterController {
     }
 
     if (! _.isEmpty(fieldObject.filters)) {
-      fieldObject.query = '(' + field + ":" + _.map(_.keys(fieldObject.filters), (key) => "\\\"" + key + "\\\"").join(' OR ') + ')';
+      fieldObject.query = '(' + field + ":" + _.map(_.keys(fieldObject.filters), (key) => key.includes('TO')?key:"\\\"" + key + "\\\"").join(' OR ') + ')';
       this.fields[field] = fieldObject;
     } else {
       delete this.fields[field];

--- a/src/components/dashboard/dashboard.component.ts
+++ b/src/components/dashboard/dashboard.component.ts
@@ -27,6 +27,11 @@ const DashboardComponent: ng.IComponentOptions = {
   controller: function($scope) {
     'ngInject';
 
+    this.initialEventCounter = 2;
+    this.initialTimeFrame;
+    this.initialQuery;
+
+
     this.dashboardOptions = {
       margins: [10, 10],
       columns: 6,
@@ -45,19 +50,49 @@ const DashboardComponent: ng.IComponentOptions = {
     };
 
     this.timeframeChange = function(timeframe) {
-      //TODO: remove event broadcast and call a widget function instead
-      $scope.$broadcast('onTimeframeChange', timeframe);
-      if (this.onTimeframeChange) {
-        this.onTimeframeChange({timeframe: timeframe});
+      if(this.initialEventCounter > 0) {
+          this.initialEventCounter--;
+      }
+      if(this.initialEventCounter == 0) {
+        //TODO: remove event broadcast and call a widget function instead
+        $scope.$broadcast('onTimeframeChange', timeframe);
+        if (this.onTimeframeChange) {
+            this.onTimeframeChange({timeframe: timeframe});
+        }
+        if(this.initialQuery) {
+            $scope.$broadcast('onQueryFilterChange', {query: this.initialQuery, source: undefined});
+            if (this.onFilterChange) {
+                this.onFilterChange({query: this.initialQuery});
+            }
+            delete(this.initialQuery);
+        }
+      } else {
+        //waiting for queryFilterChange event ==> store timeframe for further broadcast
+        this.initialTimeFrame = timeframe;
       }
     };
 
     this.queryFilterChange = function(query, widget) {
-      //TODO: remove event broadcast and call a widget function instead
-      $scope.$broadcast('onQueryFilterChange', {query: query, source: widget});
-      if (this.onFilterChange) {
-        this.onFilterChange({query: query});
-      }
+        if(this.initialEventCounter > 0) {
+          this.initialEventCounter--;
+        }
+        if(this.initialEventCounter == 0) {
+          //TODO: remove event broadcast and call a widget function instead
+          $scope.$broadcast('onQueryFilterChange', {query: query, source: widget});
+          if (this.onFilterChange) {
+            this.onFilterChange({query: query});
+          }
+          if(this.initialTimeFrame) {
+            $scope.$broadcast('onTimeframeChange', this.initialTimeFrame);
+            if (this.onTimeframeChange) {
+              this.onTimeframeChange({timeframe: this.initialTimeFrame});
+            }
+            delete(this.initialTimeFrame);
+          }
+        } else {
+          //waiting for timeFrameChange event ==> store query for further broadcast
+          this.initialQuery = query;
+        }
     };
 
     this.viewLogs = function() {


### PR DESCRIPTION
Use a counter on initialization to wait for both queryFilter and timeframe before sending an event to widgets.

Fix gravitee-io/issues#2194