### PR TITLE
fix(media): Do not append a trailing slash after a media upload.

### DIFF
--- a/src/components/documentation/page/page-editormarkdown.component.ts
+++ b/src/components/documentation/page/page-editormarkdown.component.ts
@@ -104,7 +104,7 @@ class ComponentCtrl implements ng.IComponentController {
 
           $http.post(mediaURL + "upload", fd, {headers: {"Content-Type": undefined}})
           .then((response) => {
-            callback(mediaURL + "/" + response.data, blob.name);
+            callback(mediaURL + response.data, blob.name);
           });
 
           return false;


### PR DESCRIPTION
closes gravitee-io/issues#2225