### PR TITLE
fix(): login form is now displayed when no provider is configured, ev…

### DIFF
--- a/src/management/configuration/portal/portal.component.ts
+++ b/src/management/configuration/portal/portal.component.ts
@@ -28,6 +28,12 @@ const PortalSettingsComponent: ng.IComponentOptions = {
     Constants: any
   ) {
     'ngInject';
+
+    this.$onInit = () => {
+      this.Constants.authentication.localLogin.enabled = (this.Constants.authentication.localLogin.enabled || !this.hasIdpDefined());
+      this.save();
+    }
+
     this.Constants = Constants;
 
     this.widgets = [
@@ -46,6 +52,12 @@ const PortalSettingsComponent: ng.IComponentOptions = {
         Constants = response.data;
       });
     };
+
+    this.hasIdpDefined = () => {
+      return this.Constants.authentication.google.clientId ||
+       this.Constants.authentication.github.clientId ||
+       this.Constants.authentication.oauth2.clientId;
+    }
   }
 };
 

--- a/src/management/configuration/portal/portal.html
+++ b/src/management/configuration/portal/portal.html
@@ -207,7 +207,7 @@
                 </md-checkbox>
             </md-input-container>
             <md-input-container class="gv-input-container-dense">
-                <md-checkbox ng-model="$ctrl.Constants.authentication.localLogin.enabled" aria-label="localLogin">
+                <md-checkbox ng-disabled="!$ctrl.hasIdpDefined()" ng-model="$ctrl.Constants.authentication.localLogin.enabled" aria-label="localLogin">
                     Local Login
                 </md-checkbox>
             </md-input-container>

--- a/src/user/login/login.html
+++ b/src/user/login/login.html
@@ -23,7 +23,7 @@
           <label>Log In</label>
         </div>
 
-        <form name="formUser" ng-submit="$ctrl.login()" layout="column" ng-if="!$ctrl.localLoginDisabled">
+        <form name="formUser" ng-submit="$ctrl.login()" layout="column" ng-if="!$ctrl.localLoginDisabled || $ctrl.providers.length == 0">
 
           <div layout="row">
             <ng-md-icon icon="person" style="fill: #555"></ng-md-icon>


### PR DESCRIPTION
…ent is the LocalLogin parameter is set to false in the configuration.

Moreover, it is now impossible to uncheck LocalLogin parameter when no identity provider has been configured.

Fix gravitee-io/issues#2007