### PR TITLE
fix: keep logs filters when we navigate in the browser history

### DIFF
--- a/src/management/api/analytics/apis.analytics.route.ts
+++ b/src/management/api/analytics/apis.analytics.route.ts
@@ -72,24 +72,19 @@ function apisAnalyticsRouterConfig($stateProvider) {
       },
       params: {
         from: {
-          type: 'int',
-          dynamic: true
+          type: 'int'
         },
         to: {
-          type: 'int',
-          dynamic: true
+          type: 'int'
         },
         q: {
-          type: 'string',
-          dynamic: true
+          type: 'string'
         },
         page: {
-          type: 'int',
-          dynamic: true
+          type: 'int'
         },
         size: {
-          type: 'int',
-          dynamic: true
+          type: 'int'
         }
       },
       resolve: {


### PR DESCRIPTION
fix gravitee-io/issues#2317