### PR TITLE
fix(jsonExport): fixes JsonExport for 1.15 and 1.20 and creates 1.25

### DIFF
--- a/build.json
+++ b/build.json
@@ -1,3 +1,3 @@
 {
-    "version": "1.29.0-SNAPSHOT"
+    "version": "3.0.0-SNAPSHOT"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gravitee-management-webui",
-  "version": "1.29.0-SNAPSHOT",
+  "version": "3.0.0-SNAPSHOT",
   "description": "Gravitee.io APIM - Portal",
   "dependencies": {
     "amdefine": "^1.0.1",

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 
   <groupId>io.gravitee.management</groupId>
   <artifactId>gravitee-management-webui</artifactId>
-  <version>1.29.0-SNAPSHOT</version>
+  <version>3.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Gravitee.io APIM - Portal</name>
 

--- a/src/management/api/portal/general/dialog/apiExport.dialog.html
+++ b/src/management/api/portal/general/dialog/apiExport.dialog.html
@@ -23,7 +23,8 @@
         <div layout="column" layout-align="space-between center">
           <md-select ng-model="data.exportVersion" placeholder="Export as">
             <md-option value="default" selected>Current version ({{ graviteeVersion }})</md-option>
-            <md-option value="1.20">1.20.x version</md-option>
+            <md-option value="1.25">1.25.x to 1.29.x version</md-option>
+            <md-option value="1.20">1.20.x to 1.24.x version</md-option>
             <md-option value="1.15">1.15.x to 1.16.x version</md-option>
           </md-select>
         </div>


### PR DESCRIPTION
since a Plan is linked to one api instead of many
Fixes gravitee-io/issues#2540