### PR TITLE
feat: When searching for APIs, empty input does not trigger the search

### DIFF
--- a/src/management/api/apis.controller.ts
+++ b/src/management/api/apis.controller.ts
@@ -82,7 +82,7 @@ export class ApisController {
     $scope.$watch('$ctrl.query', (query: string, previousQuery: string) => {
       $timeout.cancel(this.timer);
       this.timer = $timeout(() => {
-        if (query !== undefined && query !== previousQuery && query.length > 3) {
+        if (query !== undefined && query !== previousQuery) {
           this.search();
         }
       }, 300);

--- a/src/portal/api/api-list.controller.ts
+++ b/src/portal/api/api-list.controller.ts
@@ -82,7 +82,7 @@ export class PortalApiListController {
     $scope.$watch('apisCtrl.query', (query: string, previousQuery: string) => {
       $timeout.cancel(this.timer);
       this.timer = $timeout(() => {
-        if (query !== undefined && query !== previousQuery && query.length > 3) {
+        if (query !== undefined && query !== previousQuery) {
           this.search();
         }
       }, 300);


### PR DESCRIPTION
fix gravitee-io/issues#2559