### PR TITLE
Fix Permissions for Management UI

### DIFF
--- a/conf/browsersync.conf.js
+++ b/conf/browsersync.conf.js
@@ -26,8 +26,8 @@ module.exports = function (env) {
     },
     open: false,
     middleware: proxyMiddleware(
-      env ? `https://${env}.gravitee.io/management` : 'http://localhost:8083/management',
-      {changeOrigin: !!env, secure: false}
+      env ? `https://${env}.gravitee.io/management` : 'https://gravitee-01.dev.k8s.i-lab.online/management',
+      {changeOrigin: true, secure: false, logLevel: 'debug'}
     )
   };
 };

--- a/conf/browsersync.conf.js
+++ b/conf/browsersync.conf.js
@@ -26,8 +26,8 @@ module.exports = function (env) {
     },
     open: false,
     middleware: proxyMiddleware(
-      env ? `https://${env}.gravitee.io/management` : 'https://gravitee-01.dev.k8s.i-lab.online/management',
-      {changeOrigin: true, secure: false, logLevel: 'debug'}
+      env ? `https://${env}.gravitee.io/management` : 'http://localhost:8083/management',
+      {changeOrigin: !!env, secure: false}
     )
   };
 };

--- a/src/management/configuration/api-portal-header/api-portal-header.component.ts
+++ b/src/management/configuration/api-portal-header/api-portal-header.component.ts
@@ -20,6 +20,7 @@ import {ApiPortalHeader} from "../../../entities/apiPortalHeader";
 import PortalConfigService from "../../../services/portalConfig.service";
 import _ = require('lodash');
 import {IScope} from "angular";
+import UserService from "../../../services/user.service";
 
 const ApiPortalHeaderComponent: ng.IComponentOptions = {
   bindings: {
@@ -28,6 +29,7 @@ const ApiPortalHeaderComponent: ng.IComponentOptions = {
   template: require('./api-portal-header.html'),
   controller: function(
     ApiHeaderService: ApiHeaderService,
+    UserService: UserService,
     NotificationService: NotificationService,
     PortalConfigService: PortalConfigService,
     $mdDialog: angular.material.IDialogService,
@@ -38,7 +40,6 @@ const ApiPortalHeaderComponent: ng.IComponentOptions = {
     this.$rootScope = $rootScope;
     this.$mdDialog = $mdDialog;
     this.settings = _.cloneDeep(Constants);
-
     this.$onInit = () => {
     };
 
@@ -141,7 +142,9 @@ const ApiPortalHeaderComponent: ng.IComponentOptions = {
       });
     };
 
-
+    this.isUserHasPermissions = (permission)  => {
+      return UserService.isUserHasPermissions([permission]);
+    }
   }
 };
 

--- a/src/management/configuration/api-portal-header/api-portal-header.component.ts
+++ b/src/management/configuration/api-portal-header/api-portal-header.component.ts
@@ -143,7 +143,7 @@ const ApiPortalHeaderComponent: ng.IComponentOptions = {
     };
 
     this.isUserHasPermissions = (permission)  => {
-      return UserService.isUserHasPermissions([permission]);
+      return UserService.isUserHasPermissions(permission);
     }
   }
 };

--- a/src/management/configuration/api-portal-header/api-portal-header.html
+++ b/src/management/configuration/api-portal-header/api-portal-header.html
@@ -22,12 +22,12 @@
         <div class="gv-form-content" layout="column">
             <h3>Add extra informations</h3>
             <md-input-container class="gv-input-container-dense">
-                <md-checkbox ng-disabled="!$ctrl.isUserHasPermissions('portal-settings-c')" ng-model="$ctrl.settings.portal.apis.apiHeaderShowTags.enabled" aria-label="Show Tags" ng-change="$ctrl.saveShowTags()">
+                <md-checkbox ng-disabled="!$ctrl.isUserHasPermissions(['portal-settings-c','portal-settings-u','portal-settings-d'])" ng-model="$ctrl.settings.portal.apis.apiHeaderShowTags.enabled" aria-label="Show Tags" ng-change="$ctrl.saveShowTags()">
                     Show tags list in the API header
                 </md-checkbox>
             </md-input-container>
             <md-input-container class="gv-input-container-dense">
-                <md-checkbox ng-disabled="!$ctrl.isUserHasPermissions('portal-settings-c')" ng-model="$ctrl.settings.portal.apis.apiHeaderShowViews.enabled" aria-label="Show Views" ng-change="$ctrl.saveShowViews()">
+                <md-checkbox ng-disabled="!$ctrl.isUserHasPermissions(['portal-settings-c','portal-settings-u','portal-settings-d'])" ng-model="$ctrl.settings.portal.apis.apiHeaderShowViews.enabled" aria-label="Show Views" ng-change="$ctrl.saveShowViews()">
                     Show views list in the API header
                 </md-checkbox>
             </md-input-container>

--- a/src/management/configuration/api-portal-header/api-portal-header.html
+++ b/src/management/configuration/api-portal-header/api-portal-header.html
@@ -22,12 +22,12 @@
         <div class="gv-form-content" layout="column">
             <h3>Add extra informations</h3>
             <md-input-container class="gv-input-container-dense">
-                <md-checkbox ng-model="$ctrl.settings.portal.apis.apiHeaderShowTags.enabled" aria-label="Show Tags" ng-change="$ctrl.saveShowTags()">
+                <md-checkbox ng-disabled="!$ctrl.isUserHasPermissions('portal-settings-c')" ng-model="$ctrl.settings.portal.apis.apiHeaderShowTags.enabled" aria-label="Show Tags" ng-change="$ctrl.saveShowTags()">
                     Show tags list in the API header
                 </md-checkbox>
             </md-input-container>
             <md-input-container class="gv-input-container-dense">
-                <md-checkbox ng-model="$ctrl.settings.portal.apis.apiHeaderShowViews.enabled" aria-label="Show Views" ng-change="$ctrl.saveShowViews()">
+                <md-checkbox ng-disabled="!$ctrl.isUserHasPermissions('portal-settings-c')" ng-model="$ctrl.settings.portal.apis.apiHeaderShowViews.enabled" aria-label="Show Views" ng-change="$ctrl.saveShowViews()">
                     Show views list in the API header
                 </md-checkbox>
             </md-input-container>

--- a/src/management/configuration/application/registration/client-registration-providers.component.ts
+++ b/src/management/configuration/application/registration/client-registration-providers.component.ts
@@ -18,6 +18,7 @@ import NotificationService from "../../../../services/notification.service";
 import PortalConfigService from "../../../../services/portalConfig.service";
 import { ClientRegistrationProvider } from "../../../../entities/clientRegistrationProvider";
 import ClientRegistrationProviderService from "../../../../services/clientRegistrationProvider.service";
+import UserService from "../../../../services/user.service";
 
 const ClientRegistrationProvidersComponent: ng.IComponentOptions = {
   bindings: {
@@ -28,6 +29,7 @@ const ClientRegistrationProvidersComponent: ng.IComponentOptions = {
     $mdDialog: angular.material.IDialogService,
     ClientRegistrationProviderService: ClientRegistrationProviderService,
     PortalConfigService: PortalConfigService,
+    UserService: UserService,
     NotificationService: NotificationService,
     $state: StateService,
     Constants
@@ -97,6 +99,10 @@ const ClientRegistrationProvidersComponent: ng.IComponentOptions = {
         NotificationService.show("Application type '" + type  + "' is now " + (this.settings.application.types[type].enabled?"allowed":"disallowed") );
         _.merge(Constants, response.data);
       });
+    };
+
+    this.isUserHasPermissions = (permission)  => {
+      return UserService.isUserHasPermissions(permission);
     };
   }
 };

--- a/src/management/configuration/application/registration/client-registration-providers.html
+++ b/src/management/configuration/application/registration/client-registration-providers.html
@@ -23,34 +23,34 @@
     <div class="gv-form-content" layout="column">
       <h6>Enable Dynamic Client Registration</h6>
       <md-input-container class="gv-input-container-dense">
-        <md-checkbox ng-model="$ctrl.settings.application.registration.enabled" aria-label="Client registration" ng-change="$ctrl.saveClientRegistration()">
+        <md-checkbox ng-disabled="!$ctrl.isUserHasPermissions(['portal-settings-c','portal-settings-u','portal-settings-d'])" ng-model="$ctrl.settings.application.registration.enabled" aria-label="Client registration" ng-change="$ctrl.saveClientRegistration()">
           Client registration for applications (OpenID Connect - Dynamic Client Registration)
         </md-checkbox>
       </md-input-container>
 
       <h6>Allowed application types</h6>
       <md-input-container class="gv-input-container-dense">
-        <md-checkbox ng-model="$ctrl.settings.application.types.simple.enabled" aria-label="Allow or deny simple application type" ng-change="$ctrl.saveApplicationType('simple')">
+        <md-checkbox ng-disabled="!$ctrl.isUserHasPermissions(['portal-settings-c','portal-settings-u','portal-settings-d'])" ng-model="$ctrl.settings.application.types.simple.enabled" aria-label="Allow or deny simple application type" ng-change="$ctrl.saveApplicationType('simple')">
           Simple (A hands-free application. Using this type, you will be able to define the client_id by your own)
         </md-checkbox>
       </md-input-container>
       <md-input-container class="gv-input-container-dense">
-        <md-checkbox ng-model="$ctrl.settings.application.types.browser.enabled" aria-label="Allow or deny browser application type" ng-change="$ctrl.saveApplicationType('browser')">
+        <md-checkbox ng-disabled="!$ctrl.isUserHasPermissions(['portal-settings-c','portal-settings-u','portal-settings-d'])" ng-model="$ctrl.settings.application.types.browser.enabled" aria-label="Allow or deny browser application type" ng-change="$ctrl.saveApplicationType('browser')">
           Browser (Angular, React, ...)
         </md-checkbox>
       </md-input-container>
       <md-input-container class="gv-input-container-dense">
-        <md-checkbox ng-model="$ctrl.settings.application.types.web.enabled" aria-label="Allow or deny web application type" ng-change="$ctrl.saveApplicationType('web')">
+        <md-checkbox ng-disabled="!$ctrl.isUserHasPermissions(['portal-settings-c','portal-settings-u','portal-settings-d'])" ng-model="$ctrl.settings.application.types.web.enabled" aria-label="Allow or deny web application type" ng-change="$ctrl.saveApplicationType('web')">
           Web (Java, .Net, ...)
         </md-checkbox>
       </md-input-container>
       <md-input-container class="gv-input-container-dense">
-        <md-checkbox ng-model="$ctrl.settings.application.types.native.enabled" aria-label="Allow or deny native application type" ng-change="$ctrl.saveApplicationType('native')">
+        <md-checkbox ng-disabled="!$ctrl.isUserHasPermissions(['portal-settings-c','portal-settings-u','portal-settings-d'])" ng-model="$ctrl.settings.application.types.native.enabled" aria-label="Allow or deny native application type" ng-change="$ctrl.saveApplicationType('native')">
           Native (iOS, Android, ...)
         </md-checkbox>
       </md-input-container>
       <md-input-container class="gv-input-container-dense">
-        <md-checkbox ng-model="$ctrl.settings.application.types.backend_to_backend.enabled" aria-label="Allow or deny machine to machine application type" ng-change="$ctrl.saveApplicationType('backend_to_backend')">
+        <md-checkbox ng-disabled="!$ctrl.isUserHasPermissions(['portal-settings-c','portal-settings-u','portal-settings-d'])" ng-model="$ctrl.settings.application.types.backend_to_backend.enabled" aria-label="Allow or deny machine to machine application type" ng-change="$ctrl.saveApplicationType('backend_to_backend')">
           Backend-to-Backend
         </md-checkbox>
       </md-input-container>

--- a/src/management/configuration/identity/identity-provider.controller.ts
+++ b/src/management/configuration/identity/identity-provider.controller.ts
@@ -21,6 +21,7 @@ import IdentityProviderService from "../../../services/identityProvider.service"
 import { GroupMapping, IdentityProvider, RoleMapping } from "../../../entities/identityProvider";
 import angular = require("angular");
 import _ = require('lodash');
+import UserService from "../../../services/user.service";
 
 interface IIdentityProviderScope extends ng.IScope {
   formIdentityProvider: any;
@@ -36,6 +37,7 @@ class IdentityProviderController {
   constructor(
     private $scope: IIdentityProviderScope,
     private $state: StateService,
+    private UserService: UserService,
     private $mdEditDialog,
     private Constants,
     private $mdDialog: angular.material.IDialogService,

--- a/src/management/configuration/identity/identity-providers.component.ts
+++ b/src/management/configuration/identity/identity-providers.component.ts
@@ -20,6 +20,7 @@ import NotificationService from "../../../services/notification.service";
 import PortalConfigService from "../../../services/portalConfig.service";
 import _ = require('lodash');
 import {IScope} from 'angular';
+import UserService from "../../../services/user.service";
 
 const IdentityProvidersComponent: ng.IComponentOptions = {
   bindings: {
@@ -28,6 +29,7 @@ const IdentityProvidersComponent: ng.IComponentOptions = {
   template: require('./identity-providers.html'),
   controller: function(
     $mdDialog: angular.material.IDialogService,
+    UserService: UserService,
     IdentityProviderService: IdentityProviderService,
     PortalConfigService: PortalConfigService,
     NotificationService: NotificationService,
@@ -95,6 +97,10 @@ const IdentityProvidersComponent: ng.IComponentOptions = {
         NotificationService.show("Login form is now " + (this.settings.authentication.localLogin.enabled?"enabled":"disabled"));
       });
     };
+
+    this.isUserHasPermissions = (permission)  => {
+      return UserService.isUserHasPermissions(permission);
+    }
   }
 };
 

--- a/src/management/configuration/identity/identity-providers.html
+++ b/src/management/configuration/identity/identity-providers.html
@@ -23,12 +23,12 @@
 
       <h3>Configuration</h3>
       <md-input-container class="gv-input-container-dense">
-        <md-checkbox ng-model="$ctrl.settings.authentication.forceLogin.enabled" aria-label="Force login" ng-change="$ctrl.saveForceLogin()">
+        <md-checkbox ng-disabled="!$ctrl.isUserHasPermissions(['portal-settings-c','portal-settings-u','portal-settings-d'])" ng-model="$ctrl.settings.authentication.forceLogin.enabled" aria-label="Force login" ng-change="$ctrl.saveForceLogin()">
           Force authentication to access portal
         </md-checkbox>
       </md-input-container>
       <md-input-container class="gv-input-container-dense">
-        <md-checkbox ng-model="$ctrl.settings.authentication.localLogin.enabled" aria-label="Show login form" ng-change="$ctrl.saveShowLoginForm()">
+        <md-checkbox ng-disabled="!$ctrl.isUserHasPermissions(['portal-settings-c','portal-settings-u','portal-settings-d'])" ng-model="$ctrl.settings.authentication.localLogin.enabled" aria-label="Show login form" ng-change="$ctrl.saveShowLoginForm()">
           Show login form
         </md-checkbox>
       </md-input-container>

--- a/src/management/configuration/portal/portal.component.ts
+++ b/src/management/configuration/portal/portal.component.ts
@@ -17,6 +17,7 @@ import NotificationService from "../../../services/notification.service";
 import PortalConfigService from "../../../services/portalConfig.service";
 import { StateService } from '@uirouter/core';
 import _ = require('lodash');
+import UserService from "../../../services/user.service";
 
 const PortalSettingsComponent: ng.IComponentOptions = {
   bindings: {
@@ -26,6 +27,7 @@ const PortalSettingsComponent: ng.IComponentOptions = {
   controller: function(
     NotificationService: NotificationService,
     PortalConfigService: PortalConfigService,
+    UserService: UserService,
     $state: StateService,
     Constants: any
   ) {
@@ -55,6 +57,11 @@ const PortalSettingsComponent: ng.IComponentOptions = {
        this.settings.authentication.github.clientId ||
        this.settings.authentication.oauth2.clientId;
     }
+
+    this.isUserHasPermissions = (permission)  => {
+      return UserService.isUserHasPermissions(permission);
+    }
+
   }
 };
 

--- a/src/management/configuration/portal/portal.html
+++ b/src/management/configuration/portal/portal.html
@@ -22,7 +22,7 @@
         <div class="gv-form-content" layout="column">
             <md-input-container class="md-block" flex-gt-xs>
                 <label>Company name</label>
-                <input ng-model="$ctrl.settings.company.name">
+                <input ng-disabled="!$ctrl.isUserHasPermissions(['portal-settings-c','portal-settings-u','portal-settings-d'])" ng-model="$ctrl.settings.company.name">
             </md-input-container>
         </div>
     </div>
@@ -34,26 +34,26 @@
         <div class="gv-form-content" layout="column">
             <md-input-container class="md-block" flex>
                 <label>Title</label>
-                <input ng-model="$ctrl.settings.management.title">
+                <input ng-disabled="!$ctrl.isUserHasPermissions(['portal-settings-c','portal-settings-u','portal-settings-d'])" ng-model="$ctrl.settings.management.title">
             </md-input-container>
             <h6>Security plans type available</h6>
             <md-input-container class="gv-input-container-dense">
-                <md-checkbox ng-model="$ctrl.settings.plan.security.keyless.enabled" aria-label="A">
+                <md-checkbox ng-disabled="!$ctrl.isUserHasPermissions(['portal-settings-c','portal-settings-u','portal-settings-d'])" ng-model="$ctrl.settings.plan.security.keyless.enabled" aria-label="A">
                     Keyless plans
                 </md-checkbox>
             </md-input-container>
             <md-input-container class="gv-input-container-dense">
-                <md-checkbox ng-model="$ctrl.settings.plan.security.apikey.enabled" aria-label="A">
+                <md-checkbox ng-disabled="!$ctrl.isUserHasPermissions(['portal-settings-c','portal-settings-u','portal-settings-d'])" ng-model="$ctrl.settings.plan.security.apikey.enabled" aria-label="A">
                     Api-key plans
                 </md-checkbox>
             </md-input-container>
             <md-input-container class="gv-input-container-dense">
-                <md-checkbox ng-model="$ctrl.settings.plan.security.oauth2.enabled" aria-label="A">
+                <md-checkbox ng-disabled="!$ctrl.isUserHasPermissions(['portal-settings-c','portal-settings-u','portal-settings-d'])" ng-model="$ctrl.settings.plan.security.oauth2.enabled" aria-label="A">
                     Oauth2 plans
                 </md-checkbox>
             </md-input-container>
             <md-input-container class="gv-input-container-dense">
-                <md-checkbox ng-model="$ctrl.settings.plan.security.jwt.enabled" aria-label="A">
+                <md-checkbox ng-disabled="!$ctrl.isUserHasPermissions(['portal-settings-c','portal-settings-u','portal-settings-d'])" ng-model="$ctrl.settings.plan.security.jwt.enabled" aria-label="A">
                     JWT plans
                 </md-checkbox>
             </md-input-container>
@@ -67,61 +67,61 @@
 
             <md-input-container class="md-block" flex-gt-xs>
                 <label>Title</label>
-                <input ng-model="$ctrl.settings.portal.title">
+                <input ng-disabled="!$ctrl.isUserHasPermissions(['portal-settings-c','portal-settings-u','portal-settings-d'])" ng-model="$ctrl.settings.portal.title">
             </md-input-container>
             <md-input-container class="md-block" flex-gt-xs>
                 <label>Api-key Header
                     <small>(Used by portal to display the CURL command, change the YAML configuration to impact the gateway)</small>
                 </label>
-                <input ng-model="$ctrl.settings.portal.apikeyHeader">
+                <input ng-disabled="!$ctrl.isUserHasPermissions(['portal-settings-c','portal-settings-u','portal-settings-d'])" ng-model="$ctrl.settings.portal.apikeyHeader">
             </md-input-container>
             <md-input-container class="gv-input-container-dense">
-                <md-checkbox ng-model="$ctrl.settings.portal.apis.tilesMode.enabled" aria-label="Tiles Mode">
+                <md-checkbox ng-disabled="!$ctrl.isUserHasPermissions(['portal-settings-c','portal-settings-u','portal-settings-d'])" ng-model="$ctrl.settings.portal.apis.tilesMode.enabled" aria-label="Tiles Mode">
                     Use Tiles Mode for apis by default (if not overridden by user)
                 </md-checkbox>
             </md-input-container>
             <md-input-container class="gv-input-container-dense">
-                <md-checkbox ng-model="$ctrl.settings.portal.support.enabled" aria-label="Support">
+                <md-checkbox ng-disabled="!$ctrl.isUserHasPermissions(['portal-settings-c','portal-settings-u','portal-settings-d'])" ng-model="$ctrl.settings.portal.support.enabled" aria-label="Support">
                     Activate Support
                 </md-checkbox>
             </md-input-container>
             <md-input-container class="gv-input-container-dense">
-                <md-checkbox ng-model="$ctrl.settings.portal.rating.enabled" aria-label="Rating">
+                <md-checkbox ng-disabled="!$ctrl.isUserHasPermissions(['portal-settings-c','portal-settings-u','portal-settings-d'])" ng-model="$ctrl.settings.portal.rating.enabled" aria-label="Rating">
                     Activate Rating
                 </md-checkbox>
             </md-input-container>
             <md-input-container class="gv-input-container-dense">
-                <md-checkbox ng-model="$ctrl.settings.portal.rating.comment.mandatory" aria-label="Rating comment mandatory">
+                <md-checkbox ng-disabled="!$ctrl.isUserHasPermissions(['portal-settings-c','portal-settings-u','portal-settings-d'])" ng-model="$ctrl.settings.portal.rating.comment.mandatory" aria-label="Rating comment mandatory">
                     Force user to fill comment before to save a rating
                 </md-checkbox>
             </md-input-container>
             <md-input-container class="gv-input-container-dense">
-                <md-checkbox ng-model="$ctrl.settings.portal.devMode.enabled" aria-label="Developer Portal Only">
+                <md-checkbox ng-disabled="!$ctrl.isUserHasPermissions(['portal-settings-c','portal-settings-u','portal-settings-d'])" ng-model="$ctrl.settings.portal.devMode.enabled" aria-label="Developer Portal Only">
                     Developer Portal Only
                 </md-checkbox>
             </md-input-container>
             <md-input-container class="gv-input-container-dense">
-                <md-checkbox ng-model="$ctrl.settings.portal.userCreation.enabled" aria-label="Allow user creation">
+                <md-checkbox ng-disabled="!$ctrl.isUserHasPermissions(['portal-settings-c','portal-settings-u','portal-settings-d'])" ng-model="$ctrl.settings.portal.userCreation.enabled" aria-label="Allow user creation">
                     Allow User Registration
                 </md-checkbox>
             </md-input-container>
             <md-input-container class="gv-input-container-dense">
-                <md-checkbox ng-model="$ctrl.settings.portal.analytics.enabled" aria-label="Add Google Analytics">
+                <md-checkbox ng-disabled="!$ctrl.isUserHasPermissions(['portal-settings-c','portal-settings-u','portal-settings-d'])" ng-model="$ctrl.settings.portal.analytics.enabled" aria-label="Add Google Analytics">
                     Add Google Analytics
                 </md-checkbox>
             </md-input-container>
             <md-input-container class="md-block" flex-gt-xs>
                 <label>Google Analytics TrackingId</label>
-                <input ng-model="$ctrl.settings.portal.analytics.trackingId">
+                <input ng-disabled="!$ctrl.isUserHasPermissions(['portal-settings-c','portal-settings-u','portal-settings-d'])" ng-model="$ctrl.settings.portal.analytics.trackingId">
             </md-input-container>
             <md-input-container class="gv-input-container-dense">
-                <md-checkbox ng-model="$ctrl.settings.portal.uploadMedia.enabled" aria-label="Allow upload media">
+                <md-checkbox ng-disabled="!$ctrl.isUserHasPermissions(['portal-settings-c','portal-settings-u','portal-settings-d'])" ng-model="$ctrl.settings.portal.uploadMedia.enabled" aria-label="Allow upload media">
                     Allow Upload Images
                 </md-checkbox>
             </md-input-container>
             <md-input-container class="md-block" flex-gt-xs>
                 <label>Max size upload file (bytes)</label>
-                <input type="number" min="0" ng-model="$ctrl.settings.portal.uploadMedia.maxSizeInOctet">
+                <input ng-disabled="!$ctrl.isUserHasPermissions(['portal-settings-c','portal-settings-u','portal-settings-d'])" type="number" min="0" ng-model="$ctrl.settings.portal.uploadMedia.maxSizeInOctet">
             </md-input-container>
         </div></div>
 
@@ -132,19 +132,19 @@
         <div class="gv-form-content" layout="column">
             <md-input-container class="md-block" flex-gt-xs>
                 <label>Name</label>
-                <input ng-model="$ctrl.settings.theme.name">
+                <input ng-disabled="!$ctrl.isUserHasPermissions(['portal-settings-c','portal-settings-u','portal-settings-d'])" ng-model="$ctrl.settings.theme.name">
             </md-input-container>
             <md-input-container class="md-block" flex-gt-xs>
                 <label>Logo</label>
-                <input ng-model="$ctrl.settings.theme.logo">
+                <input ng-disabled="!$ctrl.isUserHasPermissions(['portal-settings-c','portal-settings-u','portal-settings-d'])" ng-model="$ctrl.settings.theme.logo">
             </md-input-container>
             <md-input-container class="md-block" flex-gt-xs>
                 <label>Loader</label>
-                <input ng-model="$ctrl.settings.theme.loader">
+                <input ng-disabled="!$ctrl.isUserHasPermissions(['portal-settings-c','portal-settings-u','portal-settings-d'])" ng-model="$ctrl.settings.theme.loader">
             </md-input-container>
             <md-input-container class="md-block" flex-gt-xs>
                 <label>Css file (for example themes/assets/gravitee.css)</label>
-                <input ng-model="$ctrl.settings.theme.css">
+                <input ng-disabled="!$ctrl.isUserHasPermissions(['portal-settings-c','portal-settings-u','portal-settings-d'])" ng-model="$ctrl.settings.theme.css">
             </md-input-container>
         </div></div>
 
@@ -155,11 +155,11 @@
         <div class="gv-form-content" layout="column">
             <md-input-container class="md-block" flex-gt-xs>
                 <label>Tasks (in seconds)</label>
-                <input type="number" min="0" ng-model="$ctrl.settings.scheduler.tasks">
+                <input type="number" min="0" ng-disabled="!$ctrl.isUserHasPermissions(['portal-settings-c','portal-settings-u','portal-settings-d'])" ng-model="$ctrl.settings.scheduler.tasks">
             </md-input-container>
             <md-input-container class="md-block" flex-gt-xs>
                 <label>Notifications (in seconds)</label>
-                <input type="number" min="0" ng-model="$ctrl.settings.scheduler.notifications">
+                <input type="number" min="0" ng-disabled="!$ctrl.isUserHasPermissions(['portal-settings-c','portal-settings-u','portal-settings-d'])" ng-model="$ctrl.settings.scheduler.notifications">
             </md-input-container>
         </div></div>
 
@@ -169,7 +169,7 @@
         <div class="gv-form-content" layout="column">
             <md-input-container class="md-block" flex-gt-xs>
                 <label>Documentation URL</label>
-                <input ng-model="$ctrl.settings.documentation.url">
+                <input ng-disabled="!$ctrl.isUserHasPermissions(['portal-settings-c','portal-settings-u','portal-settings-d'])" ng-model="$ctrl.settings.documentation.url">
             </md-input-container>
         </div>
     </div>
@@ -178,46 +178,46 @@
         <h2>API Quality</h2>
         <div class="gv-form-content" layout="column">
           <md-input-container class="md-block" flex-gt-xs>
-            <md-checkbox ng-model="$ctrl.settings.apiReview.enabled" aria-label="API reviews">
+            <md-checkbox ng-disabled="!$ctrl.isUserHasPermissions(['portal-settings-c','portal-settings-u','portal-settings-d'])" ng-model="$ctrl.settings.apiReview.enabled" aria-label="API reviews">
               Enable API review
             </md-checkbox>
           </md-input-container>
             <md-input-container class="md-block" flex-gt-xs>
-                <md-checkbox ng-model="$ctrl.settings.apiQualityMetrics.enabled" aria-label="Rating">
+                <md-checkbox ng-disabled="!$ctrl.isUserHasPermissions(['portal-settings-c','portal-settings-u','portal-settings-d'])" ng-model="$ctrl.settings.apiQualityMetrics.enabled" aria-label="Rating">
                     Enable API Quality Metrics
                 </md-checkbox>
             </md-input-container>
             <md-input-container class="md-block" flex-gt-xs>
                 <label>Functional documentation weight (0 means not used)</label>
-                <input type="number" min="0" ng-model="$ctrl.settings.apiQualityMetrics.functionalDocumentationWeight">
+                <input type="number" min="0" ng-disabled="!$ctrl.isUserHasPermissions(['portal-settings-c','portal-settings-u','portal-settings-d'])" ng-model="$ctrl.settings.apiQualityMetrics.functionalDocumentationWeight">
             </md-input-container>
             <md-input-container class="md-block" flex-gt-xs>
                 <label>Technical documentation weight (0 means not used)</label>
-                <input type="number" min="0" ng-model="$ctrl.settings.apiQualityMetrics.technicalDocumentationWeight">
+                <input type="number" min="0" ng-disabled="!$ctrl.isUserHasPermissions(['portal-settings-c','portal-settings-u','portal-settings-d'])" ng-model="$ctrl.settings.apiQualityMetrics.technicalDocumentationWeight">
             </md-input-container>
             <md-input-container class="md-block" flex-gt-xs>
                 <label>Healthcheck weight (0 means not used)</label>
-                <input type="number" min="0" ng-model="$ctrl.settings.apiQualityMetrics.healthcheckWeight">
+                <input type="number" min="0" ng-disabled="!$ctrl.isUserHasPermissions(['portal-settings-c','portal-settings-u','portal-settings-d'])" ng-model="$ctrl.settings.apiQualityMetrics.healthcheckWeight">
             </md-input-container>
             <md-input-container class="md-block" flex-gt-xs>
                 <label>Description weight (0 means not used)</label>
-                <input type="number" min="0" ng-model="$ctrl.settings.apiQualityMetrics.descriptionWeight">
+                <input type="number" min="0" ng-disabled="!$ctrl.isUserHasPermissions(['portal-settings-c','portal-settings-u','portal-settings-d'])" ng-model="$ctrl.settings.apiQualityMetrics.descriptionWeight">
             </md-input-container>
             <md-input-container class="md-block" flex-gt-xs>
                 <label>Description minimum length</label>
-                <input type="number" min="0" ng-model="$ctrl.settings.apiQualityMetrics.descriptionMinLength">
+                <input type="number" min="0" ng-disabled="!$ctrl.isUserHasPermissions(['portal-settings-c','portal-settings-u','portal-settings-d'])" ng-model="$ctrl.settings.apiQualityMetrics.descriptionMinLength">
             </md-input-container>
             <md-input-container class="md-block" flex-gt-xs>
                 <label>Logo weight (0 means not used)</label>
-                <input type="number" min="0" ng-model="$ctrl.settings.apiQualityMetrics.logoWeight">
+                <input type="number" min="0" ng-disabled="!$ctrl.isUserHasPermissions(['portal-settings-c','portal-settings-u','portal-settings-d'])" ng-model="$ctrl.settings.apiQualityMetrics.logoWeight">
             </md-input-container>
             <md-input-container class="md-block" flex-gt-xs>
                 <label>Views weight (0 means not used)</label>
-                <input type="number" min="0" ng-model="$ctrl.settings.apiQualityMetrics.viewsWeight">
+                <input type="number" min="0" ng-disabled="!$ctrl.isUserHasPermissions(['portal-settings-c','portal-settings-u','portal-settings-d'])" ng-model="$ctrl.settings.apiQualityMetrics.viewsWeight">
             </md-input-container>
             <md-input-container class="md-block" flex-gt-xs>
                 <label>Labels weight (0 means not used)</label>
-                <input type="number" min="0" ng-model="$ctrl.settings.apiQualityMetrics.labelsWeight">
+                <input type="number" min="0" ng-disabled="!$ctrl.isUserHasPermissions(['portal-settings-c','portal-settings-u','portal-settings-d'])" ng-model="$ctrl.settings.apiQualityMetrics.labelsWeight">
             </md-input-container>
         </div>
     </div>

--- a/src/management/configuration/settings.component.ts
+++ b/src/management/configuration/settings.component.ts
@@ -39,27 +39,27 @@ const SettingsComponent: ng.IComponentOptions = {
       },
       apiPortalHeader: {
         perm: UserService.isUserHasPermissions(
-          ['portal-api_header-c', 'portal-api_header-r', 'portal-api_header-u', 'portal-api_header-d']),
+          ['portal-api_header-r']),
         goTo: 'management.settings.apiPortalHeader'
       },
       clientRegistration: {
         perm: UserService.isUserHasPermissions(
-          ['portal-client_registration_provider-c', 'portal-client_registration_provider-r', 'portal-client_registration_provider-u', 'portal-client_registration_provider-d']),
+          ['portal-client_registration_provider-r']),
         goTo: 'management.settings.clientregistrationproviders.list'
       },
       identityProviders: {
         perm: UserService.isUserHasPermissions(
-          ['portal-identity_provider-c', 'portal-identity_provider-r', 'portal-identity_provider-u', 'portal-identity_provider-d']),
+          ['portal-identity_provider-r']),
         goTo: 'management.settings.identityproviders.list'
       },
       documentations: {
         perm: UserService.isUserHasPermissions(
-          ['portal-documentation-c', 'portal-documentation-u', 'portal-documentation-d']),
+          ['portal-documentation-r']),
         goTo: 'management.settings.documentation'
       },
       metadata: {
         perm: UserService.isUserHasPermissions(
-          ['portal-metadata-c', 'portal-metadata-u', 'portal-metadata-d']),
+          ['portal-metadata-r']),
         goTo: 'management.settings.metadata'
       },
       portalSettings: {
@@ -69,12 +69,12 @@ const SettingsComponent: ng.IComponentOptions = {
       },
       topApis: {
         perm: UserService.isUserHasPermissions(
-          ['portal-top_apis-c', 'portal-top_apis-u', 'portal-top_apis-d']),
+          ['portal-top-apis-r']),
         goTo: 'management.settings.top-apis'
       },
       views: {
         perm: UserService.isUserHasPermissions(
-          ['portal-view-c', 'portal-view-u', 'portal-view-d']),
+          ['portal-view-r', ]),
         goTo: 'management.settings.views'
       },
 
@@ -88,46 +88,46 @@ const SettingsComponent: ng.IComponentOptions = {
       // GATEWAYS
       api_logging: {
         perm: UserService.isUserHasPermissions(
-          ['portal-settings-c']),
+          ['managment-settings-r']),
         goTo: 'management.settings.api_logging'
       },
       dictionaries: {
         perm: UserService.isUserHasPermissions(
-          ['management-dictionary-c', 'management-dictionary-r', 'management-dictionary-u', 'management-dictionary-d']),
+          ['management-dictionary-r']),
         goTo: 'management.settings.dictionaries.list'
       },
       tags: {
         perm: UserService.isUserHasPermissions(
-          ['management-tag-c', 'management-tag-u', 'management-tag-d']),
+          ['management-tag-r']),
         goTo: 'management.settings.tags'
       },
       tenants: {
         perm: UserService.isUserHasPermissions(
-          ['management-tenant-c', 'management-tenant-u', 'management-tenant-d']),
+          ['management-tenant-r']),
         goTo: 'management.settings.tenants'
       },
 
       // USER MANAGEMENT
       users: {
         perm: UserService.isUserHasPermissions(
-          ['management-user-c', 'management-user-u', 'management-user-d']),
+          ['management-user-r']),
         goTo: 'management.settings.users'
       },
       groups: {
         perm: UserService.isUserHasPermissions(
-          ['management-group-c', 'management-group-r', 'management-group-u', 'management-group-d']),
+          ['management-group-r']),
         goTo: 'management.settings.groups'
       },
       roles: {
         perm: UserService.isUserHasPermissions(
-          ['management-role-c', 'management-role-u', 'management-role-d']),
+          ['management-role-r']),
         goTo: 'management.settings.roles'
       },
 
       // ALERT
       notifications: {
         perm: UserService.isUserHasPermissions(
-          ['management-notification-c', 'management-notification-u', 'management-notification-d']),
+          ['management-notification-r']),
         goTo: 'management.settings.notifications'
       }};
 

--- a/src/management/management.module.ts
+++ b/src/management/management.module.ts
@@ -822,6 +822,7 @@ angular.module('gravitee-management', [uiRouter, permission, uiPermission, 'ngMa
   // ApiHeader
   .component('configApiPortalHeader', ApiPortalHeaderComponent)
   .service('ApiHeaderService', ApiHeaderService)
+  .service('UserService', UserService)
   .controller("NewApiPortalHeaderDialogController", NewApiPortalHeaderDialogController)
   .controller("UpdateApiPortalHeaderDialogController", UpdateApiPortalHeaderDialogController)
 

--- a/src/management/management.module.ts
+++ b/src/management/management.module.ts
@@ -671,6 +671,7 @@ angular.module('gravitee-management', [uiRouter, permission, uiPermission, 'ngMa
   .component('topApis', TopApisComponent)
   .component('portalSettings', PortalSettingsComponent)
   .component('analyticsSettings', AnalyticsSettingsComponent)
+  .service('UserService', UserService)
   .directive('gvMetadataValidator', () => MetadataValidatorDirective)
 
   .component('instances', InstancesComponent)
@@ -835,12 +836,14 @@ angular.module('gravitee-management', [uiRouter, permission, uiPermission, 'ngMa
   .component('gvIdentityproviderOidc', IdentityProviderOIDCComponent)
   .controller("IdentityProviderController", IdentityProviderController)
   .service('IdentityProviderService', IdentityProviderService)
+  .service('UserService', UserService)
 
   // Settings: Client Registration
   .component('clientRegistrationProviders', ClientRegistrationProvidersComponent)
   .component('clientRegistrationProvider', ClientRegistrationProviderComponent)
   .controller('ClientRegistrationProviderController', ClientRegistrationProviderController)
   .service('ClientRegistrationProviderService', ClientRegistrationProviderService)
+  .service('UserService', UserService)
 
   // Alerts
   .service('AlertService', AlertService)


### PR DESCRIPTION
We have created own ROLES for our Gravitee Installation. And found out, that sometimes there is a wrong behaviour with the settings. Also if you do not have to write permissions to the settings endpoint and click the checkboxes on top of the portal configuration items, there will be an error thrown.

If the required permission is not available, we are deactivating the field/checkbox.