### PR TITLE
fix(api-card): logo pops up to the side if too large

### DIFF
--- a/src/portal/api/_api.scss
+++ b/src/portal/api/_api.scss
@@ -174,7 +174,7 @@ md-card-content {
 }
 
 .gravitee-media img {
-  width: auto;
+  width: 100%;
   max-width: 100px;
   max-height: 75px;
 }


### PR DESCRIPTION
fix gravitee-io/issues#2113