### PR TITLE
Changing help and notify icon color to be visible

### DIFF
--- a/themes/light-theme.json
+++ b/themes/light-theme.json
@@ -4,10 +4,10 @@
       "background-color": "#fbfbfb",
       "color": "#000",
       "help": {
-        "fill": "#fff"
+        "fill": "#4b5468"
       },
       "notifications": {
-        "fill": "#fff"
+        "fill": "#4b5468"
       },
       "user": {
         "img": {


### PR DESCRIPTION
For now, those two icon color are too closed to the background color and are not visible. it's a proposition about having more visible icons