### PR TITLE
fix: API key is displayed as a client id on the context's log

### DIFF
--- a/src/management/api/analytics/logs/log.html
+++ b/src/management/api/analytics/logs/log.html
@@ -41,7 +41,7 @@
             <table md-table class="gv-table-dense">
               <tbody md-body>
               <tr md-row ng-if="$ctrl.log.securityToken">
-                <td md-cell style="width: 1%; font-weight: bold;" nowrap>{{$ctrl.log.securityType === 'api_key'?'API key': 'Client id'}}</td>
+                <td md-cell style="width: 1%; font-weight: bold;" nowrap>{{$ctrl.log.securityType.toLowerCase() === 'api_key'?'API key': 'Client id'}}</td>
                 <td md-cell>{{$ctrl.log.securityToken}}</td>
               </tr>
               <tr md-row ng-if="$ctrl.log.application">

--- a/src/management/management.route.ts
+++ b/src/management/management.route.ts
@@ -150,7 +150,7 @@ function managementRouterConfig($stateProvider) {
           only: ['environment-platform-r']
         },
         docs: {
-          page: 'environment-dashboard'
+          page: 'management-api-logs'
         }
       },
       params: {
@@ -194,7 +194,7 @@ function managementRouterConfig($stateProvider) {
           only: ['environment-platform-r']
         },
         docs: {
-          page: 'environment-dashboard'
+          page: 'management-api-log'
         }
       }
     })

--- a/src/management/platform/logs/platform-log.html
+++ b/src/management/platform/logs/platform-log.html
@@ -42,7 +42,7 @@
               <table md-table class="gv-table-dense">
                 <tbody md-body>
                 <tr md-row ng-if="$ctrl.log.securityToken">
-                  <td md-cell style="width: 1%; font-weight: bold;" nowrap>{{$ctrl.log.securityType === 'api_key'?'API key': 'Client id'}}</td>
+                  <td md-cell style="width: 1%; font-weight: bold;" nowrap>{{$ctrl.log.securityType.toLowerCase() === 'api_key'?'API key': 'Client id'}}</td>
                   <td md-cell>{{$ctrl.log.securityToken}}</td>
                 </tr>
                 <tr md-row ng-if="$ctrl.log.application">


### PR DESCRIPTION
fix gravitee-io/issues#3759