### PR TITLE
fix(healthcheck): All widgets are refreshed when selecting a timeframe.

### DIFF
--- a/src/management/api/proxy/backend/healthcheck/healthcheck.controller.ts
+++ b/src/management/api/proxy/backend/healthcheck/healthcheck.controller.ts
@@ -56,7 +56,7 @@ class ApiHealthCheckController {
   timeframeChange(timeframe) {
     this.query.from = timeframe.from;
     this.query.to = timeframe.to;
-    this.refresh();
+    this.updateChart();
   }
 
   updateChart() {


### PR DESCRIPTION
Closes gravitee-io/issues#3865