### PR TITLE
docker: Use non-root ports to run nginx

### DIFF
--- a/docker/config/templates/default.conf.tmpl
+++ b/docker/config/templates/default.conf.tmpl
@@ -1,6 +1,6 @@
 server {
-    listen {{ getenv "HTTP_PORT" "80" }};
-    listen {{ getenv "HTTPS_PORT" "443" }};
+    listen {{ getenv "HTTP_PORT" "8080" }};
+    listen {{ getenv "HTTPS_PORT" "8443" }};
     server_name {{ getenv "SERVER_NAME" "_" }};
 
     index index.html index.htm;


### PR DESCRIPTION
Closes gravitee-io/issues#4094