### PR TITLE
fix(management): do not add empty tokens in HTTP headers

### DIFF
--- a/src/management/management.interceptor.ts
+++ b/src/management/management.interceptor.ts
@@ -118,7 +118,9 @@ function interceptorConfig(
   const csrfInterceptor = function ($q: angular.IQService, $injector: angular.auto.IInjectorService): angular.IHttpInterceptor {
     return {
       request: function (config) {
-        config.headers['X-Xsrf-Token'] = xsrfToken;
+        if (xsrfToken) {
+          config.headers['X-Xsrf-Token'] = xsrfToken;
+        }
         return config;
       },
       response: function(response) {
@@ -143,7 +145,10 @@ function interceptorConfig(
         let reCaptchaService: ReCaptchaService = $injector.get('ReCaptchaService');
 
         if (reCaptchaService && reCaptchaService.isEnabled()) {
-          config.headers[reCaptchaService.getHeaderName()] = reCaptchaService.getCurrentToken();
+          let currentReCaptchaToken = reCaptchaService.getCurrentToken();
+          if (currentReCaptchaToken) {
+            config.headers[reCaptchaService.getHeaderName()] = currentReCaptchaToken;
+          }
         }
         return config;
       }


### PR DESCRIPTION
* add X-Xsrf-Token only if not empty
* add X-ReCaptcha-Token only if not empty

Fixes gravitee-io/issues#4628