### PR TITLE
fix(theme): import/Export changes

### DIFF
--- a/src/management/configuration/theme/theme.controller.ts
+++ b/src/management/configuration/theme/theme.controller.ts
@@ -41,6 +41,7 @@ class ThemeController {
     'ngInject';
     $scope.themeForm = {};
     $scope.targetURL = Constants.portal.url;
+    $scope.maxSize = Constants.portal.uploadMedia.maxSizeInOctet;
 
     $scope.trustSrc = function (src) {
       return $sce.trustAsResourceUrl(src);
@@ -430,6 +431,7 @@ class ThemeController {
     const theme = this.$scope.theme;
     const data = {
       name: theme.name,
+      enabled: theme.enabled,
       definition: theme.definition,
       logo: theme.logo,
       optionalLogo: theme.optionalLogo,
@@ -454,7 +456,12 @@ class ThemeController {
       const reader = new FileReader();
       reader.readAsText(file);
       reader.onload = (event) => {
-        const theme = Object.assign({}, this.$scope.theme, JSON.parse(event.target.result));
+        let jsonFromFile = JSON.parse(event.target.result);
+
+        // force to false, to force the user to validate the imported theme before saving and enabling it.
+        jsonFromFile.enabled = false;
+
+        const theme = Object.assign({}, this.$scope.theme, jsonFromFile);
         this.setTheme(theme);
         this.onDataChanged();
         this.$scope.themeForm.$commitViewValue();
@@ -466,7 +473,7 @@ class ThemeController {
     if (invalidFiles && invalidFiles.length > 0) {
       const fileError = invalidFiles[0];
       if (fileError.$error === 'maxSize') {
-        this.NotificationService.showError(`Theme "${fileError.name}" exceeds the maximum authorized size (${this.$scope.maxSize})`);
+        this.NotificationService.showError(`Theme "${fileError.name}" exceeds the maximum authorized size (${this.$scope.maxSize}B)`);
       } else {
         this.NotificationService.showError(`File is not valid (error: ${fileError.$error})`);
       }

--- a/src/management/configuration/theme/theme.html
+++ b/src/management/configuration/theme/theme.html
@@ -55,7 +55,7 @@
                  ngf-select="$ctrl.importTheme($file,$invalidFiles)"
                  ngf-pattern="'application/json'"
                  ngf-accept="'application/json'"
-                 ngf-max-size="1MB"
+                 ngf-max-size="{{maxSize}}"
                  permission permission-only="['environment-theme-u']">
         Import
       </md-button>


### PR DESCRIPTION
* use the `max size upload file` parameter in the import theme form
* export the enable status of the theme and ignore it when importing theme through the UI

Fixes gravitee-io/issues#4179