### PR TITLE
fix(identity-providers): fix hasActivatedIDP method

### DIFF
--- a/src/components/identityProviders/identity-providers.component.ts
+++ b/src/components/identityProviders/identity-providers.component.ts
@@ -95,7 +95,18 @@ const IdentityProvidersComponent: ng.IComponentOptions = {
     };
 
     this.hasActivatedIdp = () => {
-      return Object.keys(this.activatedIdps).length > 0;
+      if (this.target === 'ENVIRONMENT') {
+        // activated IDP must also be enabled
+        const enabledIdpIds = this.identityProviders.filter(idp => idp.enabled === true).map(idp => idp.id);
+        for (const idpId of enabledIdpIds) {
+          if (this.activatedIdps[idpId]) {
+            return true;
+          }
+        }
+        return false;
+      } else {
+        return Object.keys(this.activatedIdps).length > 0;
+      }
     };
 
     this.saveForceLogin = () => {


### PR DESCRIPTION
`hasActivatedIDP` method is used to force or not the `localLogin` option.
For environments, IDP must be activated AND enabled to be taken into account.
For organizations, IDP just need to be activated.

Fixes gravitee-io/issues#4797