### PR TITLE
fix(management): Better handling of settings

### DIFF
--- a/src/components/documentation/edit-page.component.ts
+++ b/src/components/documentation/edit-page.component.ts
@@ -16,7 +16,7 @@
 
 import NotificationService from '../../services/notification.service';
 import DocumentationService, { FolderSituation, SystemFolderName } from '../../services/documentation.service';
-import PortalConfigService from '../../services/portalConfig.service';
+import PortalSettingsService from '../../services/portalSettings.service';
 import { StateService } from '@uirouter/core';
 import { IScope } from 'angular';
 import UserService from '../../services/user.service';
@@ -46,7 +46,7 @@ const EditPageComponent: ng.IComponentOptions = {
     NotificationService: NotificationService,
     DocumentationService: DocumentationService,
     UserService: UserService,
-    PortalConfigService: PortalConfigService,
+    PortalSettingsService: PortalSettingsService,
     $mdDialog: angular.material.IDialogService,
     $state: StateService,
     $scope: IPageScope,
@@ -114,7 +114,7 @@ const EditPageComponent: ng.IComponentOptions = {
         }
       }
 
-      PortalConfigService.get().then((response) => {
+      PortalSettingsService.get().then((response) => {
         this.settings = response.data;
         this.shouldShowOpenApiDocFormat = this.settings &&
           this.settings.openAPIDocViewer &&

--- a/src/components/documentation/new-page.component.ts
+++ b/src/components/documentation/new-page.component.ts
@@ -16,7 +16,7 @@
 
 import NotificationService from '../../services/notification.service';
 import DocumentationService, { FolderSituation, SystemFolderName } from '../../services/documentation.service';
-import PortalConfigService from '../../services/portalConfig.service';
+import PortalSettingsService from '../../services/portalSettings.service';
 import { StateService } from '@uirouter/core';
 import { IScope } from 'angular';
 import _ = require('lodash');
@@ -38,7 +38,7 @@ const NewPageComponent: ng.IComponentOptions = {
   controller: function (
     NotificationService: NotificationService,
     DocumentationService: DocumentationService,
-    PortalConfigService: PortalConfigService,
+    PortalSettingsService: PortalSettingsService,
     $state: StateService,
     $scope: IPageScope
   ) {
@@ -81,7 +81,7 @@ const NewPageComponent: ng.IComponentOptions = {
       $scope.fetcherJsonSchema = this.emptyFetcher;
       this.fetcherJsonSchemaForm = ['*'];
 
-      PortalConfigService.get().then((response) => {
+      PortalSettingsService.get().then((response) => {
         let settings = response.data;
 
         if (this.page.type === 'SWAGGER' && settings && settings.openAPIDocViewer) {

--- a/src/components/identityProviders/identity-providers.component.ts
+++ b/src/components/identityProviders/identity-providers.component.ts
@@ -17,11 +17,11 @@ import { StateService } from '@uirouter/core';
 import { IdentityProvider, IdentityProviderActivation } from '../../entities/identityProvider';
 import IdentityProviderService from '../../services/identityProvider.service';
 import NotificationService from '../../services/notification.service';
-import PortalConfigService from '../../services/portalConfig.service';
+import PortalSettingsService from '../../services/portalSettings.service';
 import { IScope } from 'angular';
 import OrganizationService from '../../services/organization.service';
 import EnvironmentService from '../../services/environment.service';
-import ConsoleConfigService from '../../services/consoleConfig.service';
+import ConsoleSettingsService from '../../services/consoleSettings.service';
 import _ = require('lodash');
 
 const IdentityProvidersComponent: ng.IComponentOptions = {
@@ -37,8 +37,8 @@ const IdentityProvidersComponent: ng.IComponentOptions = {
     IdentityProviderService: IdentityProviderService,
     EnvironmentService: EnvironmentService,
     OrganizationService: OrganizationService,
-    ConsoleConfigService: ConsoleConfigService,
-    PortalConfigService: PortalConfigService,
+    ConsoleSettingsService: ConsoleSettingsService,
+    PortalSettingsService: PortalSettingsService,
     NotificationService: NotificationService,
     $state: StateService,
     Constants,
@@ -99,7 +99,7 @@ const IdentityProvidersComponent: ng.IComponentOptions = {
     };
 
     this.saveForceLogin = () => {
-      PortalConfigService.save({
+      PortalSettingsService.save({
         authentication: {
           forceLogin: {
             enabled: this.settings.authentication.forceLogin.enabled
@@ -113,7 +113,7 @@ const IdentityProvidersComponent: ng.IComponentOptions = {
 
     this.saveShowLoginForm = () => {
       if (this.target === 'ENVIRONMENT') {
-        PortalConfigService.save({
+        PortalSettingsService.save({
           authentication: {
             localLogin: {
               enabled: this.settings.authentication.localLogin.enabled
@@ -124,7 +124,7 @@ const IdentityProvidersComponent: ng.IComponentOptions = {
           Constants.env.authentication.localLogin = response.data.authentication.localLogin;
         });
       } else {
-        ConsoleConfigService.save({
+        ConsoleSettingsService.save({
           authentication: {
             localLogin: {
               enabled: this.settings.authentication.localLogin.enabled
@@ -168,9 +168,9 @@ const IdentityProvidersComponent: ng.IComponentOptions = {
 
     this.isReadonlySetting = (property: string): boolean => {
       if (this.target === 'ENVIRONMENT') {
-        return PortalConfigService.isReadonly(this.settings, property);
+        return PortalSettingsService.isReadonly(this.settings, property);
       } else {
-        return ConsoleConfigService.isReadonly(this.settings, property);
+        return ConsoleSettingsService.isReadonly(this.settings, property);
       }
     };
   }

--- a/src/components/sidenav/sidenav.component.ts
+++ b/src/components/sidenav/sidenav.component.ts
@@ -15,7 +15,7 @@
  */
 import { IScope, IWindowService } from 'angular';
 import { StateService } from '@uirouter/core';
-import PortalConfigService from '../../services/portalConfig.service';
+import PortalSettingsService from '../../services/portalSettings.service';
 
 
 export const SidenavComponent: ng.IComponentOptions = {
@@ -31,14 +31,14 @@ export const SidenavComponent: ng.IComponentOptions = {
     $scope: IScope,
     $state: StateService,
     $rootScope: IScope,
-    PortalConfigService: PortalConfigService) {
+    PortalSettingsService: PortalSettingsService) {
     'ngInject';
     const lastEnvironmentLoaded = 'gv-last-environment-loaded';
     const reduceModeKey = 'gv-sidenav-reduce-mode';
     this.$window = $window;
     this.reducedMode = false;
     this.Constants = Constants;
-    this.PortalConfigService = PortalConfigService;
+    this.PortalSettingsService = PortalSettingsService;
     this.$state = $state;
 
     this.$onInit = () => {
@@ -49,7 +49,7 @@ export const SidenavComponent: ng.IComponentOptions = {
     };
 
     this.updateCurrentEnvSettings = () => {
-      PortalConfigService.get().then(response => {
+      PortalSettingsService.get().then(response => {
         Constants.env.settings = response.data;
         $rootScope.$broadcast('graviteePortalUrlRefresh', Constants.env.settings.portal.url);
       });

--- a/src/management/api/portal/subscriptions/dialog/subscription.create.dialog.controller.ts
+++ b/src/management/api/portal/subscriptions/dialog/subscription.create.dialog.controller.ts
@@ -16,7 +16,7 @@
 import * as _ from 'lodash';
 import ApiService from '../../../../../services/api.service';
 import ApplicationService from '../../../../../services/application.service';
-import PortalConfigService from '../../../../../services/portalConfig.service';
+import PortalSettingsService from '../../../../../services/portalSettings.service';
 
 function DialogSubscriptionCreateController(
   $mdDialog: angular.material.IDialogService,
@@ -24,7 +24,7 @@ function DialogSubscriptionCreateController(
   api,
   ApplicationService: ApplicationService,
   ApiService: ApiService,
-  PortalConfigService: PortalConfigService,
+  PortalSettingsService: PortalSettingsService,
   Constants: any) {
   'ngInject';
   this.api = api;

--- a/src/management/configuration/analytics/analytics.component.ts
+++ b/src/management/configuration/analytics/analytics.component.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import NotificationService from '../../../services/notification.service';
-import PortalConfigService from '../../../services/portalConfig.service';
+import PortalSettingsService from '../../../services/portalSettings.service';
 import { StateService } from '@uirouter/core';
 import DashboardService from '../../../services/dashboard.service';
 import { Dashboard } from '../../../entities/dashboard';
@@ -29,7 +29,7 @@ const AnalyticsSettingsComponent: ng.IComponentOptions = {
   template: require('./analytics.html'),
   controller: function(
     NotificationService: NotificationService,
-    PortalConfigService: PortalConfigService,
+    PortalSettingsService: PortalSettingsService,
     $state: StateService,
     Constants: any,
     $mdDialog: angular.material.IDialogService,
@@ -54,7 +54,7 @@ const AnalyticsSettingsComponent: ng.IComponentOptions = {
     };
 
     this.save = () => {
-      PortalConfigService.save(this.settings).then( (response) => {
+      PortalSettingsService.save(this.settings).then( (response) => {
         _.merge(Constants.env.settings, response.data);
         NotificationService.show('Configuration saved');
         this.formSettings.$setPristine();
@@ -111,7 +111,7 @@ const AnalyticsSettingsComponent: ng.IComponentOptions = {
     };
 
     this.isReadonlySetting = (property: string): boolean => {
-      return PortalConfigService.isReadonly(this.settings, property);
+      return PortalSettingsService.isReadonly(this.settings, property);
     };
   }
 };

--- a/src/management/configuration/api-portal-header/api-portal-header.component.ts
+++ b/src/management/configuration/api-portal-header/api-portal-header.component.ts
@@ -16,7 +16,7 @@
 import NotificationService from '../../../services/notification.service';
 import ApiHeaderService from '../../../services/apiHeader.service';
 import { ApiPortalHeader } from '../../../entities/apiPortalHeader';
-import PortalConfigService from '../../../services/portalConfig.service';
+import PortalSettingsService from '../../../services/portalSettings.service';
 import { IScope } from 'angular';
 import _ = require('lodash');
 
@@ -28,7 +28,7 @@ const ApiPortalHeaderComponent: ng.IComponentOptions = {
   controller: function(
     ApiHeaderService: ApiHeaderService,
     NotificationService: NotificationService,
-    PortalConfigService: PortalConfigService,
+    PortalSettingsService: PortalSettingsService,
     $mdDialog: angular.material.IDialogService,
     Constants,
     $rootScope: IScope
@@ -115,7 +115,7 @@ const ApiPortalHeaderComponent: ng.IComponentOptions = {
     };
 
     this.saveShowCategories = () => {
-      PortalConfigService.save({
+      PortalSettingsService.save({
         portal: {
           apis: {
             apiHeaderShowCategories: {
@@ -130,7 +130,7 @@ const ApiPortalHeaderComponent: ng.IComponentOptions = {
     };
 
     this.saveShowTags = () => {
-      PortalConfigService.save({
+      PortalSettingsService.save({
         portal: {
           apis: {
             apiHeaderShowTags: {
@@ -145,7 +145,7 @@ const ApiPortalHeaderComponent: ng.IComponentOptions = {
     };
 
     this.isReadonlySetting = (property: string): boolean => {
-      return PortalConfigService.isReadonly(this.settings, property);
+      return PortalSettingsService.isReadonly(this.settings, property);
     };
   }
 };

--- a/src/management/configuration/api-quality-rules/api-quality-rules.component.ts
+++ b/src/management/configuration/api-quality-rules/api-quality-rules.component.ts
@@ -16,7 +16,7 @@
 import _ = require('lodash');
 import { IScope } from 'angular';
 import NotificationService from '../../../services/notification.service';
-import PortalConfigService from '../../../services/portalConfig.service';
+import PortalSettingsService from '../../../services/portalSettings.service';
 
 const ApiQualityRulesComponent: ng.IComponentOptions = {
   bindings: {
@@ -26,7 +26,7 @@ const ApiQualityRulesComponent: ng.IComponentOptions = {
   controller: function(
     Constants,
     $rootScope: IScope,
-    PortalConfigService: PortalConfigService,
+    PortalSettingsService: PortalSettingsService,
     NotificationService: NotificationService,
     $mdDialog: angular.material.IDialogService) {
     'ngInject';
@@ -35,7 +35,7 @@ const ApiQualityRulesComponent: ng.IComponentOptions = {
     this.providedConfigurationMessage = 'Configuration provided by the system';
 
     this.save = () => {
-      PortalConfigService.save(this.settings).then( (response) => {
+      PortalSettingsService.save(this.settings).then( (response) => {
         _.merge(Constants.env.settings, response.data);
         NotificationService.show('API Quality settings saved!');
         this.formQuality.$setPristine();
@@ -64,7 +64,7 @@ const ApiQualityRulesComponent: ng.IComponentOptions = {
     };
 
     this.isReadonlySetting = (property: string): boolean => {
-      return PortalConfigService.isReadonly(this.settings, property);
+      return PortalSettingsService.isReadonly(this.settings, property);
     };
   }
 };

--- a/src/management/configuration/api_logging/api_logging.component.ts
+++ b/src/management/configuration/api_logging/api_logging.component.ts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 const ApiLoggingComponent: ng.IComponentOptions = {
+  bindings: {
+    settings: '<',
+  },
   controller: 'ApiLoggingController',
   template: require('./api_logging.html')
 };

--- a/src/management/configuration/api_logging/api_logging.controller.ts
+++ b/src/management/configuration/api_logging/api_logging.controller.ts
@@ -14,29 +14,28 @@
  * limitations under the License.
  */
 import NotificationService from '../../../services/notification.service';
-import ConsoleConfigService from '../../../services/consoleConfig.service';
+import ConsoleSettingsService from '../../../services/consoleSettings.service';
 
 class ApiLoggingController {
 
   public providedConfigurationMessage = 'Configuration provided by the system';
   private formApiLogging: any;
+  private settings: any;
 
-  constructor(private ConsoleConfigService: ConsoleConfigService,
-              private NotificationService: NotificationService,
-              private Constants: any) {
+  constructor(private ConsoleSettingsService: ConsoleSettingsService,
+              private NotificationService: NotificationService) {
     'ngInject';
-    this.Constants = Constants;
   }
 
   save() {
-    this.ConsoleConfigService.save().then( () => {
+    this.ConsoleSettingsService.save(this.settings).then( () => {
       this.NotificationService.show('API logging saved');
       this.formApiLogging.$setPristine();
     });
   }
 
   isReadonlySetting(property: string): boolean {
-    return this.ConsoleConfigService.isReadonly(this.Constants.org.settings, property);
+    return this.ConsoleSettingsService.isReadonly(this.settings, property);
   }
 }
 

--- a/src/management/configuration/api_logging/api_logging.html
+++ b/src/management/configuration/api_logging/api_logging.html
@@ -21,21 +21,21 @@
       <h1>API logging</h1>
       <div class="gv-form">
         <md-input-container class="md-block" flex-gt-xs>
-          <md-checkbox ng-model="$ctrl.Constants.org.settings.logging.audit.enabled" aria-label="Audit on API Logging"
+          <md-checkbox ng-model="$ctrl.settings.logging.audit.enabled" aria-label="Audit on API Logging"
                        ng-disabled="$ctrl.isReadonlySetting('logging.audit.enabled')">
             Enable audit on API Logging consultation
             <md-tooltip ng-if="$ctrl.isReadonlySetting('logging.audit.enabled')">{{$ctrl.providedConfigurationMessage}}</md-tooltip>
           </md-checkbox>
         </md-input-container>
         <md-input-container class="md-block" flex-gt-xs>
-          <md-checkbox ng-model="$ctrl.Constants.org.settings.logging.user.displayed" aria-label="End user on API Logging"
+          <md-checkbox ng-model="$ctrl.settings.logging.user.displayed" aria-label="End user on API Logging"
                        ng-disabled="$ctrl.isReadonlySetting('logging.user.displayed')">
             Display end user on API Logging (in case of OAuth2/JWT plan)
             <md-tooltip ng-if="$ctrl.isReadonlySetting('logging.user.displayed')">{{$ctrl.providedConfigurationMessage}}</md-tooltip>
           </md-checkbox>
         </md-input-container>
         <md-input-container class="md-block" flex-gt-xs>
-          <md-checkbox ng-model="$ctrl.Constants.org.settings.logging.audit.trail.enabled" aria-label="Generate API Logging audit trail"
+          <md-checkbox ng-model="$ctrl.settings.logging.audit.trail.enabled" aria-label="Generate API Logging audit trail"
                        ng-disabled="$ctrl.isReadonlySetting('logging.audit.trail.enabled')">
             Generate API Logging audit events (API_LOGGING_ENABLED, API_LOGGING_DISABLED, API_LOGGING_UPDATED)
             <md-tooltip ng-if="$ctrl.isReadonlySetting('logging.audit.trail.enabled')">{{$ctrl.providedConfigurationMessage}}</md-tooltip>
@@ -44,7 +44,7 @@
         <div class="gv-form-content" layout="column">
           <md-input-container class="md-block" flex-gt-xs>
             <label>Maximum duration (in milliseconds) when a logging mode is activated (0 means no max duration)</label>
-            <input type="number" min="0" ng-model="$ctrl.Constants.org.settings.logging.maxDurationMillis"
+            <input type="number" min="0" ng-model="$ctrl.settings.logging.maxDurationMillis"
                    ng-disabled="$ctrl.isReadonlySetting('logging.default.max.duration')">
             <md-tooltip ng-if="$ctrl.isReadonlySetting('logging.default.max.duration')">{{$ctrl.providedConfigurationMessage}}</md-tooltip>
           </md-input-container>

--- a/src/management/configuration/application/registration/client-registration-providers.component.ts
+++ b/src/management/configuration/application/registration/client-registration-providers.component.ts
@@ -15,7 +15,7 @@
  */
 import { StateService } from '@uirouter/core';
 import NotificationService from '../../../../services/notification.service';
-import PortalConfigService from '../../../../services/portalConfig.service';
+import PortalSettingsService from '../../../../services/portalSettings.service';
 import { ClientRegistrationProvider } from '../../../../entities/clientRegistrationProvider';
 import ClientRegistrationProviderService from '../../../../services/clientRegistrationProvider.service';
 import _ = require('lodash');
@@ -28,7 +28,7 @@ const ClientRegistrationProvidersComponent: ng.IComponentOptions = {
   controller: function(
     $mdDialog: angular.material.IDialogService,
     ClientRegistrationProviderService: ClientRegistrationProviderService,
-    PortalConfigService: PortalConfigService,
+    PortalSettingsService: PortalSettingsService,
     NotificationService: NotificationService,
     $state: StateService,
     Constants
@@ -68,7 +68,7 @@ const ClientRegistrationProvidersComponent: ng.IComponentOptions = {
     };
 
     this.saveClientRegistration = () => {
-      PortalConfigService.save({
+      PortalSettingsService.save({
         application: {
           registration: {
             enabled: this.settings.application.registration.enabled
@@ -95,14 +95,14 @@ const ClientRegistrationProvidersComponent: ng.IComponentOptions = {
         enabled: this.settings.application.types[type].enabled
       };
 
-      PortalConfigService.save(appType).then( response => {
+      PortalSettingsService.save(appType).then( response => {
         NotificationService.show('Application type \'' + type  + '\' is now ' + (this.settings.application.types[type].enabled ? 'allowed' : 'disallowed') );
         _.merge(Constants.env.settings, response.data);
       });
     };
 
     this.isReadonlySetting = (property: string): boolean => {
-      return PortalConfigService.isReadonly(this.settings, property);
+      return PortalSettingsService.isReadonly(this.settings, property);
     };
   }
 };

--- a/src/management/configuration/categories/categories.controller.ts
+++ b/src/management/configuration/categories/categories.controller.ts
@@ -17,7 +17,7 @@ import * as _ from 'lodash';
 import CategoryService from '../../../services/category.service';
 import NotificationService from '../../../services/notification.service';
 import { StateService } from '@uirouter/core';
-import PortalConfigService from '../../../services/portalConfig.service';
+import PortalSettingsService from '../../../services/portalSettings.service';
 import { IScope } from 'angular';
 
 class CategoriesController {
@@ -34,7 +34,7 @@ class CategoriesController {
     private $q: ng.IQService,
     private $mdDialog: angular.material.IDialogService,
     private $state: StateService,
-    private PortalConfigService: PortalConfigService,
+    private PortalSettingsService: PortalSettingsService,
     Constants: any,
     private $rootScope: IScope) {
     'ngInject';
@@ -72,7 +72,7 @@ class CategoriesController {
   }
 
   toggleDisplayMode() {
-    this.PortalConfigService.save(this.settings).then( (response) => {
+    this.PortalSettingsService.save(this.settings).then( (response) => {
       _.merge(this.Constants.env.settings, response.data);
       this.NotificationService.show('Display mode saved!');
     });
@@ -97,7 +97,7 @@ class CategoriesController {
   }
 
   isReadonlySetting(property: string): boolean {
-    return this.PortalConfigService.isReadonly(this.settings, property);
+    return this.PortalSettingsService.isReadonly(this.settings, property);
   }
 
   private reorder(from, to) {

--- a/src/management/configuration/configuration.route.ts
+++ b/src/management/configuration/configuration.route.ts
@@ -33,6 +33,8 @@ import QualityRuleService from '../../services/qualityRule.service';
 import DashboardService from '../../services/dashboard.service';
 import CustomUserFieldsService from '../../services/custom-user-fields.service';
 import EnvironmentService from '../../services/environment.service';
+import PortalSettingsService from '../../services/portalSettings.service';
+import ConsoleSettingsService from '../../services/consoleSettings.service';
 import _ = require('lodash');
 
 export default configurationRouterConfig;
@@ -128,7 +130,8 @@ function configurationRouterConfig($stateProvider) {
       resolve: {
         tags: (TagService: TagService) => TagService.list().then(response => response.data),
         entrypoints: (EntrypointService: EntrypointService) => EntrypointService.list().then(response => response.data),
-        groups: (GroupService: GroupService) => GroupService.list().then(response => response.data)
+        groups: (GroupService: GroupService) => GroupService.list().then(response => response.data),
+        settings: (PortalSettingsService: PortalSettingsService) => PortalSettingsService.get().then(response => response.data),
       },
       data: {
         menu: null,
@@ -546,7 +549,8 @@ function configurationRouterConfig($stateProvider) {
       url: '/portal',
       component: 'portalSettings',
       resolve: {
-        tags: (TagService: TagService) => TagService.list().then(response => response.data)
+        tags: (TagService: TagService) => TagService.list().then(response => response.data),
+        settings: (PortalSettingsService: PortalSettingsService) => PortalSettingsService.get().then(response => response.data),
       },
       data: {
         menu: null,
@@ -747,13 +751,16 @@ function configurationRouterConfig($stateProvider) {
     .state('management.settings.api_logging', {
       url: '/api_logging',
       component: 'apiLogging',
+      resolve: {
+        settings: (ConsoleSettingsService: ConsoleSettingsService) => ConsoleSettingsService.get().then(response => response.data)
+      },
       data: {
         menu: null,
         docs: {
           page: 'management-configuration-apilogging'
         },
         perms: {
-          only: ['environment-settings-r']
+          only: ['organization-settings-r']
         }
       }
     })

--- a/src/management/configuration/portal/portal.component.ts
+++ b/src/management/configuration/portal/portal.component.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import NotificationService from '../../../services/notification.service';
-import PortalConfigService from '../../../services/portalConfig.service';
+import PortalSettingsService from '../../../services/portalSettings.service';
 import { StateService } from '@uirouter/core';
 import CorsService from '../../../services/cors.service';
 import ApiService from '../../../services/api.service';
@@ -22,19 +22,19 @@ import _ = require('lodash');
 
 const PortalSettingsComponent: ng.IComponentOptions = {
   bindings: {
-    tags: '<'
+    tags: '<',
+    settings: '<'
   },
   template: require('./portal.html'),
   controller: function(
     NotificationService: NotificationService,
-    PortalConfigService: PortalConfigService,
+    PortalSettingsService: PortalSettingsService,
     CorsService: CorsService,
     ApiService: ApiService,
     $state: StateService,
     Constants: any
   ) {
     'ngInject';
-    this.settings = _.cloneDeep(Constants.env.settings);
     this.methods = CorsService.getHttpMethods();
     this.headers = ApiService.defaultHttpHeaders();
     this.searchHeaders = null;
@@ -50,24 +50,11 @@ const PortalSettingsComponent: ng.IComponentOptions = {
     };
 
     this.save = () => {
-      PortalConfigService.save(this.settings).then( (response) => {
-        // We have to manually set this property because lodash's merge do not handle well the case of label deletion
-        Constants.env.settings.api.labelsDictionary = response.data.api.labelsDictionary;
-        Constants.env.settings.cors.allowOrigin = response.data.cors.allowOrigin;
-        Constants.env.settings.cors.allowHeaders = response.data.cors.allowHeaders;
-        Constants.env.settings.cors.allowMethods = response.data.cors.allowMethods;
-        Constants.env.settings.cors.exposedHeaders = response.data.cors.exposedHeaders;
+      PortalSettingsService.save(this.settings).then( (response) => {
         _.merge(Constants.env.settings, response.data);
         NotificationService.show('Configuration saved');
-        this.reset();
         $state.reload();
       });
-    };
-
-    this.reset = () => {
-      this.settings = _.cloneDeep(Constants.env.settings);
-      this.formSettings.$setPristine();
-
     };
 
     this.hasIdpDefined = () => {
@@ -86,7 +73,7 @@ const PortalSettingsComponent: ng.IComponentOptions = {
     };
 
     this.isReadonlySetting = (property: string): boolean => {
-      return PortalConfigService.isReadonly(this.settings, property);
+      return PortalSettingsService.isReadonly(this.settings, property);
     };
 
     this.controlAllowOrigin = (chip, index) => {

--- a/src/management/configuration/tags/tags.component.ts
+++ b/src/management/configuration/tags/tags.component.ts
@@ -17,7 +17,8 @@ const TagsComponent: ng.IComponentOptions = {
   bindings: {
     tags: '<',
     entrypoints: '<',
-    groups: '<'
+    groups: '<',
+    settings: '<',
   },
   controller: 'TagsController',
   template: require('./tags.html')

--- a/src/management/configuration/tags/tags.controller.ts
+++ b/src/management/configuration/tags/tags.controller.ts
@@ -17,8 +17,9 @@ import * as _ from 'lodash';
 import TagService from '../../../services/tag.service';
 import NotificationService from '../../../services/notification.service';
 import EntrypointService from '../../../services/entrypoint.service';
-import PortalConfigService from '../../../services/portalConfig.service';
-import {IScope} from 'angular';
+import PortalSettingsService from '../../../services/portalSettings.service';
+import { IScope } from 'angular';
+import { StateService } from '@uirouter/core';
 
 class TagsController {
 
@@ -27,6 +28,7 @@ class TagsController {
   private groups: Array<any>;
   private entrypoints: Array<any>;
   private formSettings: any;
+  private settings: any;
 
   constructor(
     private TagService: TagService,
@@ -35,9 +37,10 @@ class TagsController {
     private $mdEditDialog,
     private $mdDialog: angular.material.IDialogService,
     private EntrypointService: EntrypointService,
-    private Constants,
-    private PortalConfigService: PortalConfigService,
-    private $rootScope: IScope) {
+    private PortalSettingsService: PortalSettingsService,
+    private $rootScope: IScope,
+    private $state: StateService) {
+
     'ngInject';
     this.$rootScope = $rootScope;
   }
@@ -103,17 +106,14 @@ class TagsController {
   }
 
   saveSettings = () => {
-    this.PortalConfigService.save().then( () => {
+    this.PortalSettingsService.save(this.settings).then( () => {
       this.NotificationService.show('Configuration saved!');
       this.formSettings.$setPristine();
     });
   }
 
   resetSettings = () => {
-    this.PortalConfigService.get().then((response) => {
-      this.Constants = response.data;
-      this.formSettings.$setPristine();
-    });
+    this.$state.reload();
   }
 
   groupNames = (groups) => {
@@ -124,7 +124,7 @@ class TagsController {
   }
 
   isReadonlySetting(property: string): boolean {
-    return this.PortalConfigService.isReadonly(this.Constants, property);
+    return this.PortalSettingsService.isReadonly(this.settings, property);
   }
 }
 

--- a/src/management/configuration/tags/tags.html
+++ b/src/management/configuration/tags/tags.html
@@ -66,7 +66,7 @@
       <div class="gv-form-content" layout="column">
         <md-input-container class="md-block" flex-gt-xs>
           <label>Entrypoint</label>
-          <input ng-model="$ctrl.Constants.env.settings.portal.entrypoint"
+          <input ng-model="$ctrl.settings.portal.entrypoint"
                  ng-disabled="$ctrl.isReadonlySetting('portal.entrypoint')">
           <md-tooltip ng-if="$ctrl.isReadonlySetting('portal.entrypoint')">{{$ctrl.providedConfigurationMessage}}</md-tooltip>
         </md-input-container>

--- a/src/management/management.module.ts
+++ b/src/management/management.module.ts
@@ -319,8 +319,8 @@ import AuditComponent from '../components/audit/audit.component';
 // Configuration
 import SettingsComponent from '../management/configuration/settings.component';
 import OrganizationSettingsComponent from '../organization/configuration/organization-settings.component';
-import ConsoleConfigService from '../services/consoleConfig.service';
-import PortalConfigService from '../services/portalConfig.service';
+import ConsoleSettingsService from '../services/consoleSettings.service';
+import PortalSettingsService from '../services/portalSettings.service';
 import ApiLoggingComponent from '../management/configuration/api_logging/api_logging.component';
 import ApiLoggingController from '../management/configuration/api_logging/api_logging.controller';
 // Users
@@ -987,8 +987,8 @@ const graviteeManagementModule = angular.module('gravitee-management', [uiRouter
   // Configuration
   graviteeManagementModule.component('settings', SettingsComponent);
   graviteeManagementModule.component('organizationSettings', OrganizationSettingsComponent);
-  graviteeManagementModule.service('ConsoleConfigService', ConsoleConfigService);
-  graviteeManagementModule.service('PortalConfigService', PortalConfigService);
+  graviteeManagementModule.service('ConsoleSettingsService', ConsoleSettingsService);
+  graviteeManagementModule.service('PortalSettingsService', PortalSettingsService);
   graviteeManagementModule.component('apiLogging', ApiLoggingComponent);
   graviteeManagementModule.controller('ApiLoggingController', ApiLoggingController);
 

--- a/src/management/management.run.ts
+++ b/src/management/management.run.ts
@@ -16,10 +16,10 @@
 /* global setInterval:false, clearInterval:false, screen:false */
 import UserService from '../services/user.service';
 import EnvironmentService from '../services/environment.service';
-import PortalConfigService from '../services/portalConfig.service';
+import PortalSettingsService from '../services/portalSettings.service';
 
 function runBlock($rootScope, $window, $http, $mdSidenav, $transitions, $state,
-                  $timeout, UserService: UserService, Constants, PermissionStrategies, ReCaptchaService, ApiService, EnvironmentService: EnvironmentService, PortalConfigService: PortalConfigService) {
+                  $timeout, UserService: UserService, Constants, PermissionStrategies, ReCaptchaService, ApiService, EnvironmentService: EnvironmentService, PortalSettingsService: PortalSettingsService) {
   'ngInject';
 
   $transitions.onStart({
@@ -58,7 +58,7 @@ function runBlock($rootScope, $window, $http, $mdSidenav, $transitions, $state,
         })
         .then((environments) => {
           if (environments && environments.length >= 1) {
-            return PortalConfigService.get();
+            return PortalSettingsService.get();
           }
         })
         .then(response => {

--- a/src/organization/configuration/console/console.component.ts
+++ b/src/organization/configuration/console/console.component.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import NotificationService from '../../../services/notification.service';
-import ConsoleConfigService from '../../../services/consoleConfig.service';
+import ConsoleSettingsService from '../../../services/consoleSettings.service';
 import { StateService } from '@uirouter/core';
 import CorsService from '../../../services/cors.service';
 import ApiService from '../../../services/api.service';
@@ -22,19 +22,19 @@ import _ = require('lodash');
 
 const ConsoleSettingsComponent: ng.IComponentOptions = {
   bindings: {
-    tags: '<'
+    tags: '<',
+    settings: '<'
   },
   template: require('./console.html'),
   controller: function(
     NotificationService: NotificationService,
-    ConsoleConfigService: ConsoleConfigService,
+    ConsoleSettingsService: ConsoleSettingsService,
     CorsService: CorsService,
     ApiService: ApiService,
     $state: StateService,
     Constants: any
   ) {
     'ngInject';
-    this.settings = _.cloneDeep(Constants.org.settings);
     this.methods = CorsService.getHttpMethods();
     this.headers = ApiService.defaultHttpHeaders();
     this.searchHeaders = null;
@@ -49,22 +49,11 @@ const ConsoleSettingsComponent: ng.IComponentOptions = {
     };
 
     this.save = () => {
-      ConsoleConfigService.save(this.settings).then( (response) => {
-        // We have to manually set this property because lodash's merge do not handle well the case of label deletion
-        Constants.org.settings.cors.allowOrigin = response.data.cors.allowOrigin;
-        Constants.org.settings.cors.allowHeaders = response.data.cors.allowHeaders;
-        Constants.org.settings.cors.allowMethods = response.data.cors.allowMethods;
-        Constants.org.settings.cors.exposedHeaders = response.data.cors.exposedHeaders;
+      ConsoleSettingsService.save(this.settings).then( (response) => {
         _.merge(Constants.org.settings, response.data);
         NotificationService.show('Configuration saved');
-        this.reset();
         $state.reload();
       });
-    };
-
-    this.reset = () => {
-      this.settings = _.cloneDeep(Constants.org.settings);
-      this.formSettings.$setPristine();
     };
 
     this.hasIdpDefined = () => {
@@ -74,7 +63,7 @@ const ConsoleSettingsComponent: ng.IComponentOptions = {
     };
 
     this.isReadonlySetting = (property: string): boolean => {
-      return ConsoleConfigService.isReadonly(this.settings, property);
+      return ConsoleSettingsService.isReadonly(this.settings, property);
     };
 
     this.controlAllowOrigin = (chip, index) => {

--- a/src/organization/organization.route.ts
+++ b/src/organization/organization.route.ts
@@ -20,6 +20,7 @@ import IdentityProviderService from '../services/identityProvider.service';
 import GroupService from '../services/group.service';
 import OrganizationService from '../services/organization.service';
 import NotificationTemplatesService from '../services/notificationTemplates.service';
+import ConsoleSettingsService from '../services/consoleSettings.service';
 
 export default organizationRouterConfig;
 
@@ -34,6 +35,9 @@ function organizationRouterConfig($stateProvider) {
     .state('organization.settings', {
       url: '/settings',
       component: 'organizationSettings',
+      resolve: {
+        settings: (ConsoleSettingsService: ConsoleSettingsService) => ConsoleSettingsService.get().then(response => response.data)
+      },
       data: {
         menu: null,
         perms: {

--- a/src/services/consoleSettings.service.ts
+++ b/src/services/consoleSettings.service.ts
@@ -14,22 +14,20 @@
  * limitations under the License.
  */
 
-class ConsoleConfigService {
-  private consoleURL: string;
-  private settings: any;
+class ConsoleSettingsService {
+  private settingsURL: string;
 
-  constructor(private $http, private $q, Constants) {
+  constructor(private $http, Constants) {
     'ngInject';
-    this.consoleURL = `${Constants.org.baseURL}/console/`;
-    this.settings = Constants.org.settings;
+    this.settingsURL = `${Constants.org.baseURL}/settings/`;
   }
 
-  save(config?) {
-    return this.$http.post(this.consoleURL, config ? config : this.settings);
+  save(config) {
+    return this.$http.post(this.settingsURL, config);
   }
 
   get() {
-    return this.$http.get(this.consoleURL);
+    return this.$http.get(this.settingsURL);
   }
 
   isReadonly(settings: any, property: string): boolean {
@@ -40,4 +38,4 @@ class ConsoleConfigService {
   }
 }
 
-export default ConsoleConfigService;
+export default ConsoleSettingsService;

--- a/src/services/portalSettings.service.ts
+++ b/src/services/portalSettings.service.ts
@@ -14,22 +14,20 @@
  * limitations under the License.
  */
 
-class PortalConfigService {
-  private portalURL: string;
-  private settings: any;
+class PortalSettingsService {
+  private settingsURL: string;
 
-  constructor(private $http, private $q, Constants) {
+  constructor(private $http, Constants) {
     'ngInject';
-    this.portalURL = `${Constants.env.baseURL}/portal/`;
-    this.settings = Constants.env.settings;
+    this.settingsURL = `${Constants.env.baseURL}/settings/`;
   }
 
-  save(config?) {
-    return this.$http.post(this.portalURL, config ? config : this.settings);
+  save(config) {
+    return this.$http.post(this.settingsURL, config);
   }
 
   get() {
-    return this.$http.get(this.portalURL);
+    return this.$http.get(this.settingsURL);
   }
 
   isReadonly(settings: any, property: string): boolean {
@@ -40,4 +38,4 @@ class PortalConfigService {
   }
 }
 
-export default PortalConfigService;
+export default PortalSettingsService;


### PR DESCRIPTION
* Rename Portal and Console xxxConfigService to xxxSettingsService...
* ... and use new resources to get and save settings  (/organization/orgID/settings & organization/orgID/environments/envID/settings)
* Call the "light" console config at startup

Closes gravitee-io/issues#4804