### PR TITLE
fix(console): display tooltip only if email exists

### DIFF
--- a/src/management/api/apis.html
+++ b/src/management/api/apis.html
@@ -91,8 +91,8 @@
                 <td md-cell nowrap>
                   <span>
                   {{::api.owner.displayName}}
-                    <md-tooltip>
-                      <span ng-if="api.owner.email">{{::api.owner.email}}</span>
+                    <md-tooltip ng-if="api.owner.email">
+                      <span>{{::api.owner.email}}</span>
                     </md-tooltip>
                   </span>
                 </td>


### PR DESCRIPTION
Fixes gravitee-io/issues#4840