### PR TITLE
feat(policy-studio): manage plan permissions in policy studio

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gravitee-management-webui",
-  "version": "3.4.2",
+  "version": "3.4.3-SNAPSHOT",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.4.3-SNAPSHOT",
   "description": "Gravitee.io APIM - Portal",
   "dependencies": {
-    "@gravitee/ui-components": "1.0.15",
+    "@gravitee/ui-components": "1.0.18-SNAPSHOT",
     "@highcharts/map-collection": "^1.1.3",
     "@toast-ui/editor": "^2.1.1",
     "@toast-ui/editor-plugin-code-syntax-highlight": "^1.0.0",

--- a/src/management/api/design/policy-studio/policy-studio.controller.ts
+++ b/src/management/api/design/policy-studio/policy-studio.controller.ts
@@ -35,6 +35,7 @@ class ApiPolicyStudioController {
     private $rootScope,
     private $stateParams,
     private $location,
+    private UserService,
   ) {
     'ngInject';
   }
@@ -119,7 +120,9 @@ class ApiPolicyStudioController {
     this.studio.setAttribute('has-policy-filter', 'true');
     this.studio.setAttribute('sortable', 'true');
     this.studio.setAttribute('can-add', 'true');
-    this.studio.setAttribute('has-plans', 'true');
+    if (!this.UserService.isUserHasPermissions(['api-plan-u'])) {
+      this.studio.setAttribute('readonly-plans', 'true');
+    }
     this.studio.addEventListener('gv-policy-studio:save', this.onSave.bind(this));
     this.studio.addEventListener('gv-policy-studio:select-flows', this.onSelectFlows.bind(this));
     this.studio.addEventListener('gv-policy-studio:change-tab', this.onChangeTab.bind(this));
@@ -135,7 +138,7 @@ class ApiPolicyStudioController {
         'version': this.api.version,
         'flows': this.api.flows != null ? this.api.flows : [],
         'resources': this.api.resources,
-        'plans': this.api.plans != null ? this.api.plans : [],
+        'plans': this.UserService.isUserHasPermissions(['api-plan-r', 'api-plan-u']) && this.api.plans != null ? this.api.plans : [],
         'properties': this.api.properties,
       };
       this.studio.services = this.api.services;


### PR DESCRIPTION
* use 1.0.18 version of ui-components
* use user permissions to configure policy-studio attributes (plans and readonly-plans)

Closes gravitee-io/issues#4770