### PR TITLE
fix(management): fix attached media removing

### DIFF
--- a/src/components/documentation/edit-page.component.ts
+++ b/src/components/documentation/edit-page.component.ts
@@ -496,7 +496,7 @@ const EditPageComponent: ng.IComponentOptions = {
         }
       }).then(function (response) {
         if (response) {
-          that.page.attached_media = that.page.attached_media.filter(media => !(media.mediaHash === resource.id && media.mediaName === resource.fileName && media.attachedAt === resource.createAt));
+          that.page.attached_media = that.page.attached_media.filter(media => !(media.mediaHash === resource.hash && media.mediaName === resource.fileName && media.attachedAt === resource.createAt));
           DocumentationService.update(that.page, that.apiId)
             .then(
               response => that.reset()


### PR DESCRIPTION
use media hash instead of id to find the media to remove.

Fixes gravitee-io/issues#4702