### PR TITLE
fix: prevent infinite redirection loop

### DIFF
--- a/src/management/management.run.ts
+++ b/src/management/management.run.ts
@@ -51,6 +51,7 @@ function runBlock($rootScope, $window, $http, $mdSidenav, $transitions, $state,
       if (!EnvironmentService.isSameEnvironment(Constants.org.currentEnv, params.environmentId)) {
         if (!params.environmentId) {
           params.environmentId = EnvironmentService.getFirstHridOrElseId(Constants.org.currentEnv);
+          return stateService.target(toState, params, { reload: false });
         }
         let targetEnv = EnvironmentService.getEnvironmentFromHridOrId(Constants.org.environments, params.environmentId);
         if (targetEnv) {


### PR DESCRIPTION
Fixes https://github.com/gravitee-io/issues/issues/5030

Avoid infinite redirection loop when a component redirects directly when it inits
It is the case for companents filtered by a timerange (logs, healthcheck logs, ...).