### PR TITLE
feat.(cicd-pipeline): maven and git release, with nexus staging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 parameters:
   gio_action:
     type: enum
-    enum: [release, pr_build]
+    enum: [release, nexus_staging, pr_build]
     default: pr_build
   dry_run:
     type: boolean
@@ -15,12 +15,16 @@ parameters:
     description: "Maven ID of the Maven profile to use for a dry run ?"
   secrethub_org:
     type: string
-    default: "gravitee-lab"
+    default: "gravitee-io"
     description: "SecretHub Org to use to fetch secrets ?"
   secrethub_repo:
     type: string
     default: "cicd"
     description: "SecretHub Repo to use to fetch secrets ?"
+  s3_bucket_name:
+    type: string
+    default: $s3_bucket_name
+    description: "Name of the S3 Bucket used to store and retrieve the state of the maven project, to perform the nexus staging ?"
 
 orbs:
   gravitee: gravitee-io/gravitee@dev:1.0.4
@@ -34,30 +38,39 @@ workflows:
       - gravitee/pr-build:
           context: cicd-orchestrator
   release:
-    # see https://circleci.com/docs/2.0/configuration-reference/#logic-statement-examples
     when:
       and:
         - equal: [ release, << pipeline.parameters.gio_action >> ]
         - not: << pipeline.parameters.dry_run >>
     jobs:
-      # return to simple definition :
       - gravitee/release:
           context: cicd-orchestrator
           dry_run: << pipeline.parameters.dry_run >>
           secrethub_org: << pipeline.parameters.secrethub_org >>
           secrethub_repo: << pipeline.parameters.secrethub_repo >>
           maven_profile_id: << pipeline.parameters.maven_profile_id >>
+          s3_bucket_name: << pipeline.parameters.s3_bucket_name >>
   release_dry_run:
-    # see https://circleci.com/docs/2.0/configuration-reference/#logic-statement-examples
     when:
       and:
         - equal: [ release, << pipeline.parameters.gio_action >> ]
         - << pipeline.parameters.dry_run >>
     jobs:
-      # return to simple definition :
       - gravitee/release:
           context: cicd-orchestrator
           dry_run: << pipeline.parameters.dry_run >>
           secrethub_org: << pipeline.parameters.secrethub_org >>
           secrethub_repo: << pipeline.parameters.secrethub_repo >>
           maven_profile_id: << pipeline.parameters.maven_profile_id >>
+          s3_bucket_name: << pipeline.parameters.s3_bucket_name >>
+
+  nexus_staging:
+    when:
+      equal: [ nexus_staging, << pipeline.parameters.gio_action >> ]
+    jobs:
+      - gravitee/nexus_staging:
+          context: cicd-orchestrator
+          secrethub_org: << pipeline.parameters.secrethub_org >>
+          secrethub_repo: << pipeline.parameters.secrethub_repo >>
+          maven_profile_id: << pipeline.parameters.maven_profile_id >>
+          s3_bucket_name: << pipeline.parameters.s3_bucket_name >>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,8 @@
   <parent>
     <groupId>io.gravitee</groupId>
     <artifactId>gravitee-parent</artifactId>
-    <version>17.1</version>
+    <!--<version>17.1</version>-->
+    <version>17.2</version>
   </parent>
 
   <groupId>io.gravitee.management</groupId>
@@ -89,6 +90,7 @@
             <exclude>.*/**</exclude>
             <exclude>**/*.adoc</exclude>
             <exclude>node_modules/**</exclude>
+            <exclude>.circleci/**</exclude>
           </excludes>
         </configuration>
       </plugin>


### PR DESCRIPTION
  New Pipeline Definition, to support "_nexus staging_" new CI CD Operation. So this pipeline brings support for the automation of the following CI CD Operations :
  * maven and git release : maven and git release, `mvn deploy` to private artifactory
  * nexus staging : mvn deploys to nexus staging to publish the artifacts to public Sonatype Nexus maven repository.
  * added exclude filter for the whole `.circleci/` directory, otherwise the [build fails because of the maven license plugin complaining `config.yml` does not have the license headers](https://app.circleci.com/pipelines/github/gravitee-io/gravitee-management-webui/692/workflows/7a154a8b-118c-43fe-bddd-9acd47783cc4/jobs/677)

  Note :
  * We will test this pipeline definition with support release `1.25.27`
  * when merged in `master`, everyone will get the new pipeline definition on their brach by git rebasing from `master`
