### PR TITLE
feat(management): don't link an API to a PO group

### DIFF
--- a/src/management/api/creation/steps/api-creation-step1.html
+++ b/src/management/api/creation/steps/api-creation-step1.html
@@ -72,11 +72,11 @@
           </md-input-container>
         </div>
 
-        <div layout-gt-sm="row" ng-if="$ctrl.parent.groups && $ctrl.parent.groups.length > 0">
+        <div layout-gt-sm="row" ng-if="$ctrl.parent.attachableGroups && $ctrl.parent.attachableGroups.length > 0">
           <md-input-container class="flex">
             <label>Groups</label>
             <md-select ng-model="$ctrl.parent.api.groups" multiple>
-              <md-option ng-repeat="group in $ctrl.parent.groups" ng-value="group">{{group.name}}</md-option>
+              <md-option ng-repeat="group in $ctrl.parent.attachableGroups" ng-value="group">{{group.name}}</md-option>
             </md-select>
             <div class="hint">Groups that will be able to access the API.</div>
           </md-input-container>

--- a/src/management/api/creation/steps/api-creation.controller.ts
+++ b/src/management/api/creation/steps/api-creation.controller.ts
@@ -16,7 +16,7 @@
 import * as _ from 'lodash';
 import ApiService from '../../../../services/api.service';
 import NotificationService from '../../../../services/notification.service';
-import {StateService} from '@uirouter/core';
+import { StateService } from '@uirouter/core';
 import NewApiController, {
   getDefinitionVersionDescription,
   getDefinitionVersionTitle
@@ -26,6 +26,7 @@ class ApiCreationController {
 
   api: any;
   selectedTenants: any[];
+  attachableGroups: any[];
 
   private parent: NewApiController;
   private vm: {
@@ -118,6 +119,10 @@ class ApiCreationController {
 
     // init documentation settings
     this.initDocumentationSettings();
+  }
+
+  $onInit = () => {
+    this.attachableGroups = this.groups.filter(group => group.apiPrimaryOwner == null);
   }
 
   /*

--- a/src/management/api/portal/general/apiPortal.controller.ts
+++ b/src/management/api/portal/general/apiPortal.controller.ts
@@ -24,6 +24,7 @@ class ApiPortalController {
   private initialApi: any;
   private api: any;
   private groups: any;
+  private attachableGroups: any;
   private categories: any;
   private tags: any;
   private tenants: any;
@@ -113,6 +114,7 @@ class ApiPortalController {
 
     this.tags = resolvedTags;
     this.groups = resolvedGroups;
+    this.attachableGroups = resolvedGroups.filter(group => group.apiPrimaryOwner == null);
 
     this.headers = [
       'Accept', 'Accept-Charset', 'Accept-Encoding', 'Accept-Language', 'Accept-Ranges', 'Access-Control-Allow-Credentials',

--- a/src/management/api/portal/userGroupAccess/groups/groups.html
+++ b/src/management/api/portal/userGroupAccess/groups/groups.html
@@ -26,8 +26,8 @@
 
   <md-input-container permission permission-only="'api-definition-u'" class="flex">
     <label>Groups</label>
-    <md-select ng-model="portalCtrl.api.groups" multiple ng-disabled="!(portalCtrl.groups && portalCtrl.groups.length > 0)">
-      <md-option ng-repeat="group in portalCtrl.groups" ng-value="group.id">
+    <md-select ng-model="portalCtrl.api.groups" multiple ng-disabled="!(portalCtrl.attachableGroups && portalCtrl.attachableGroups.length > 0)">
+      <md-option ng-repeat="group in portalCtrl.attachableGroups" ng-value="group.id">
         {{group.name}}
       </md-option>
     </md-select>

--- a/src/management/configuration/groups/group/addMemberDialog.controller.ts
+++ b/src/management/configuration/groups/group/addMemberDialog.controller.ts
@@ -29,7 +29,8 @@ function DialogAddGroupMemberController(
   apiRoles: Role[],
   applicationRoles: Role[],
   canChangeDefaultApiRole,
-  canChangeDefaultApplicationRole
+  canChangeDefaultApplicationRole,
+  isApiRoleDisabled
   ) {
   'ngInject';
 
@@ -45,6 +46,7 @@ function DialogAddGroupMemberController(
 
   this.canChangeDefaultApiRole = canChangeDefaultApiRole;
   this.canChangeDefaultApplicationRole = canChangeDefaultApplicationRole;
+  this.isApiRoleDisabled = isApiRoleDisabled;
 
   this.hide = () => {
     $mdDialog.cancel();
@@ -71,15 +73,6 @@ function DialogAddGroupMemberController(
 
   this.invalid = () => {
     return (!this.defaultApiRole && !this.defaultApplicationRole) || (this.usersSelected.length === 0);
-  };
-
-  this.isApiRoleDisabled = (role: Role) => {
-    return (
-      (role.system && role.name !== 'PRIMARY_OWNER') ||
-      (role.system &&
-        role.name === 'PRIMARY_OWNER' &&
-        this.group.apiPrimaryOwner != null)
-    );
   };
 
 }

--- a/src/management/configuration/groups/group/group.component.ts
+++ b/src/management/configuration/groups/group/group.component.ts
@@ -70,6 +70,8 @@ const GroupComponent: ng.IComponentOptions = {
 
       this.apiByDefault = this.group.event_rules && this.group.event_rules.findIndex(rule => rule.event === 'API_CREATE') !== -1;
       this.applicationByDefault = this.group.event_rules && this.group.event_rules.findIndex(rule => rule.event === 'APPLICATION_CREATE') !== -1;
+
+      this.loadGroupApis();
     };
 
     this.updateRole = (member: any) => {
@@ -165,7 +167,8 @@ const GroupComponent: ng.IComponentOptions = {
           apiRoles: this.apiRoles,
           applicationRoles: this.applicationRoles,
           canChangeDefaultApiRole: this.canChangeDefaultApiRole,
-          canChangeDefaultApplicationRole: this.canChangeDefaultApplicationRole
+          canChangeDefaultApplicationRole: this.canChangeDefaultApplicationRole,
+          isApiRoleDisabled: this.isApiRoleDisabled
         }
       }).then( (members) => {
         if (members) {
@@ -236,7 +239,7 @@ const GroupComponent: ng.IComponentOptions = {
     this.showInviteMemberModal = () => {
       $mdDialog.show({
         controller: function($mdDialog, group, apiRoles, applicationRoles, defaultApiRole, defaultApplicationRole,
-                             canChangeDefaultApiRole, canChangeDefaultApplicationRole) {
+                             canChangeDefaultApiRole, canChangeDefaultApplicationRole, isApiRoleDisabled) {
           'ngInject';
           this.group = group;
           this.group.api_role = group.api_role || defaultApiRole;
@@ -245,6 +248,7 @@ const GroupComponent: ng.IComponentOptions = {
           this.applicationRoles = applicationRoles;
           this.canChangeDefaultApiRole = canChangeDefaultApiRole;
           this.canChangeDefaultApplicationRole = canChangeDefaultApplicationRole;
+          this.isApiRoleDisabled = isApiRoleDisabled;
           this.hide = function () {$mdDialog.hide(); };
           this.save = function () {$mdDialog.hide(this.email); };
         },
@@ -258,7 +262,8 @@ const GroupComponent: ng.IComponentOptions = {
           apiRoles: this.apiRoles,
           applicationRoles: this.applicationRoles,
           canChangeDefaultApiRole: this.canChangeDefaultApiRole,
-          canChangeDefaultApplicationRole: this.canChangeDefaultApplicationRole
+          canChangeDefaultApplicationRole: this.canChangeDefaultApplicationRole,
+          isApiRoleDisabled: this.isApiRoleDisabled
         }
       }).then((email) => {
         if (email) {
@@ -315,9 +320,11 @@ const GroupComponent: ng.IComponentOptions = {
         (role.system && role.name !== 'PRIMARY_OWNER') ||
         (role.system &&
           role.name === 'PRIMARY_OWNER' &&
-          this.group.apiPrimaryOwner != null)
+          (this.group.apiPrimaryOwner != null ||
+            ($scope.groupApis && $scope.groupApis.length > 0)))
       );
     };
+
 
   }
 };

--- a/src/management/configuration/groups/group/inviteMember.dialog.html
+++ b/src/management/configuration/groups/group/inviteMember.dialog.html
@@ -26,7 +26,7 @@
                    class="md-no-underline" ng-disabled="!$ctrl.canChangeDefaultApiRole()">
           <md-option ng-repeat="role in $ctrl.apiRoles"
                      ng-value="role.name"
-                     ng-disabled="role.system">
+                     ng-disabled="$ctrl.isApiRoleDisabled(role)">
             {{role.name}}
           </md-option>
         </md-select>


### PR DESCRIPTION
* filters groups list when creating an API
* disables the PO role when the group is already linked to an API

Closes gravitee-io/issues#5162