### PR TITLE
Feature/5016 define group as po of an api

### DIFF
--- a/build.json
+++ b/build.json
@@ -1,3 +1,3 @@
 {
-    "version": "3.6.0"
+    "version": "3.7.0-SNAPSHOT"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gravitee-management-webui",
-  "version": "3.6.0",
+  "version": "3.7.0-SNAPSHOT",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gravitee-management-webui",
-  "version": "3.6.0",
+  "version": "3.7.0-SNAPSHOT",
   "description": "Gravitee.io APIM - Portal",
   "dependencies": {
     "@gravitee/ui-components": "^1.2.0",

--- a/src/components/import/import-api.component.ts
+++ b/src/components/import/import-api.component.ts
@@ -17,6 +17,8 @@ import { StateService } from '@uirouter/core';
 import { IScope } from 'angular';
 import NotificationService from '../../services/notification.service';
 import ApiService from '../../services/api.service';
+import UserService from '../../services/user.service';
+import ApiPrimaryOwnerModeService from '../../services/apiPrimaryOwnerMode.service';
 import _ = require('lodash');
 
 
@@ -34,6 +36,8 @@ const ImportComponent: ng.IComponentOptions = {
     $mdDialog: angular.material.IDialogService,
     NotificationService: NotificationService,
     ApiService: ApiService,
+    UserService: UserService,
+    ApiPrimaryOwnerModeService: ApiPrimaryOwnerModeService,
     $attrs,
   ) {
 
@@ -59,6 +63,8 @@ const ImportComponent: ng.IComponentOptions = {
       this.importCreatePathMapping = true;
       this.importCreateMocks = false;
       this.error = null;
+      this.importError = null;
+      this.computeRightToImport();
       $scope.$watch('$ctrl.importAPIFile.content', function (data) {
         if (data) {
           that.enableFileImport = true;
@@ -78,6 +84,21 @@ const ImportComponent: ng.IComponentOptions = {
 
     this.cancel = () => {
       this.cancelAction();
+    };
+
+    this.computeRightToImport = () => {
+      if (ApiPrimaryOwnerModeService.isGroupOnly()) {
+        UserService.getUserGroups(UserService.currentUser.id).then(response => {
+          if (response.data.every(group => group.apiPrimaryOwner == null)) {
+            this.importError = {
+              title: 'You are not allowed to import an API',
+              message: [
+                'You must belong to at least one group with an API primary owner member'
+              ]
+            };
+          }
+        });
+      }
     };
 
     this.isSwaggerImport = () => {

--- a/src/components/import/import-api.html
+++ b/src/components/import/import-api.html
@@ -72,11 +72,14 @@
     </div>
   </div>
 </md-dialog-content>
+<div class="gv-error-container" ng-if="$ctrl.importError" style="margin: 0 24px;">
+  <gv-error error="$ctrl.importError"></gv-error>
+</div>
 <md-dialog-actions layout="row" class="gv-import-api-actions">
   <div  ng-show="$ctrl.hasCancel()">
     <md-button md-no-ink ng-click="$ctrl.cancel()">Cancel</md-button>
   </div>
   <div>
-    <md-button ng-disabled="!$ctrl.enableImport()" ng-click="$ctrl.importAPI()" class="md-raised" ng-class="{'md-warn': $ctrl.isForUpdate()}">Import</md-button>
+    <md-button ng-disabled="!$ctrl.enableImport() || $ctrl.importError" ng-click="$ctrl.importAPI()" class="md-raised" ng-class="{'md-warn': $ctrl.isForUpdate()}">Import</md-button>
   </div>
 </md-dialog-actions>

--- a/src/components/user-autocomplete/user-autocomplete.component.ts
+++ b/src/components/user-autocomplete/user-autocomplete.component.ts
@@ -23,6 +23,7 @@ const UserAutocompleteComponent: ng.IComponentOptions = {
     selectedUser: '<',
     userFilterFn: '<',
     defaultUsersList: '<',
+    disabled: '<'
   }
 };
 

--- a/src/components/user-autocomplete/user-autocomplete.controller.ts
+++ b/src/components/user-autocomplete/user-autocomplete.controller.ts
@@ -25,6 +25,7 @@ class UserAutocompleteController {
   private selectedUser: string;
   private userFilterFn;
   private defaultUsersList: any[];
+  private disabled: boolean;
 
   private minLength: number;
   private autofocus: boolean;

--- a/src/components/user-autocomplete/user-autocomplete.html
+++ b/src/components/user-autocomplete/user-autocomplete.html
@@ -26,6 +26,7 @@
   placeholder="{{ $ctrl.placeHolder }}"
   md-autofocus="$ctrl.autofocus"
   md-menu-class="gv-user-autocomplete-menu"
+  ng-disabled="$ctrl.disabled"
 >
   <md-item-template>
     <md-list-item>

--- a/src/management/api/creation/steps/api-creation-step1.component.ts
+++ b/src/management/api/creation/steps/api-creation-step1.component.ts
@@ -13,11 +13,46 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import ApiCreationController from './api-creation.controller';
+import ApiPrimaryOwnerModeService from '../../../../services/apiPrimaryOwnerMode.service';
+
 const ApiCreationStep1Component: ng.IComponentOptions = {
   require: {
     parent: '^apiCreation'
   },
-  template: require('./api-creation-step1.html')
+  template: require('./api-creation-step1.html'),
+  controller: class {
+    private parent: ApiCreationController;
+    private advancedMode: boolean;
+    private useGroupAsPrimaryOwner: boolean;
+
+    constructor(private ApiPrimaryOwnerModeService: ApiPrimaryOwnerModeService) {
+      'ngInject';
+      this.advancedMode = false;
+      this.useGroupAsPrimaryOwner = this.ApiPrimaryOwnerModeService.isGroupOnly();
+    }
+
+    toggleAdvancedMode = () => {
+      this.advancedMode = !this.advancedMode;
+      if (!this.advancedMode) {
+        this.parent.api.groups = [];
+      }
+    }
+
+    canUseAdvancedMode = () => {
+      return (
+        (this.ApiPrimaryOwnerModeService.isHybrid() &&
+          ((this.parent.attachableGroups &&
+            this.parent.attachableGroups.length > 0) ||
+            (this.parent.poGroups && this.parent.poGroups.length > 0))) ||
+        (this.ApiPrimaryOwnerModeService.isGroupOnly() &&
+          this.parent.attachableGroups &&
+          this.parent.attachableGroups.length > 0)
+      );
+    }
+
+
+  }
 };
 
 export default ApiCreationStep1Component;

--- a/src/management/api/creation/steps/api-creation-step1.html
+++ b/src/management/api/creation/steps/api-creation-step1.html
@@ -18,12 +18,12 @@
 <md-step label="General" md-complete="$ctrl.parent.vm.stepData[0].data.completed">
   <md-step-body>
     <md-content layout-padding class="gv-creation-general-content gv-creation-content">
+      <div ng-if="$ctrl.canUseAdvancedMode()" layout="row" layout-align="end start"><a ng-click="$ctrl.toggleAdvancedMode()">Advanced mode</a></div>
       <form name="apiGeneralForm" ng-submit="$ctrl.parent.validFirstStep($ctrl.parent.vm.stepData[0].data)">
         <div layout-gt-sm="row">
           <md-input-container class="md-block" flex-gt-sm>
             <label>Name</label>
-            <input ng-model="$ctrl.parent.api.name" type="text" required name="name"
-                   md-maxlength="512" autofocus />
+            <input ng-model="$ctrl.parent.api.name" type="text" required name="name" md-maxlength="512" autofocus />
             <div class="hint" ng-if="apiGeneralForm.name.$valid || apiGeneralForm.name.$pristine">API Name</div>
             <div ng-messages="apiGeneralForm.name.$error">
               <div ng-message="required">API Name is required.</div>
@@ -32,10 +32,8 @@
           </md-input-container>
           <md-input-container class="md-block">
             <label>Version</label>
-            <input ng-model="$ctrl.parent.api.version" type="text" md-maxlength="32" required name="version">
-            <div class="hint" ng-if="apiGeneralForm.version.$valid || apiGeneralForm.version.$pristine">API
-              Version (ex: 1.0)
-            </div>
+            <input ng-model="$ctrl.parent.api.version" type="text" md-maxlength="32" required name="version" />
+            <div class="hint" ng-if="apiGeneralForm.version.$valid || apiGeneralForm.version.$pristine">API Version (ex: 1.0)</div>
             <div ng-messages="apiGeneralForm.version.$error">
               <div ng-message="required">API Version is required.</div>
               <div ng-message="md-maxlength">The version has to be less than 32 characters long.</div>
@@ -46,7 +44,7 @@
         <div layout-gt-sm="row">
           <md-input-container class="md-block" flex-gt-sm>
             <label>Description</label>
-            <input ng-model="$ctrl.parent.api.description" type="text" required name="description">
+            <input ng-model="$ctrl.parent.api.description" type="text" required name="description" />
             <div class="hint" ng-if="apiGeneralForm.description.$valid || apiGeneralForm.description.$pristine">
               Provide a description of your API, what it does, ...
             </div>
@@ -59,29 +57,55 @@
         <div layout-gt-sm="row">
           <md-input-container class="md-block" flex-gt-sm>
             <label>Context-path</label>
-            <input ng-model="$ctrl.parent.api.proxy.context_path" type="text" minlength="3"
-                   ng-pattern="/^\/[\/.a-zA-Z0-9-_]+$/" required name="contextPath" ng-change="$ctrl.parent.onChangeContextPath()">
+            <input
+              ng-model="$ctrl.parent.api.proxy.context_path"
+              type="text"
+              minlength="3"
+              ng-pattern="/^\/[\/.a-zA-Z0-9-_]+$/"
+              required
+              name="contextPath"
+              ng-change="$ctrl.parent.onChangeContextPath()"
+            />
             <div class="hint" ng-if="apiGeneralForm.contextPath.$valid || apiGeneralForm.contextPath.$pristine">
               Path where API is exposed, must start with a '/' and must contain any letter, capitalize letter, number, dash or underscore.
             </div>
             <div ng-messages="apiGeneralForm.contextPath.$error">
               <div ng-message="required">Context path is required.</div>
               <div ng-message="minlength">Context path has to be more than 3 characters long.</div>
-              <div ng-message="pattern">Context path is not valid (must start with a '/' and must contain any letter, capitalize letter, number, dash or underscore)</div>
+              <div ng-message="pattern">
+                Context path is not valid (must start with a '/' and must contain any letter, capitalize letter, number, dash or underscore)
+              </div>
             </div>
           </md-input-container>
         </div>
 
-        <div layout-gt-sm="row" ng-if="$ctrl.parent.groups && $ctrl.parent.groups.length > 0">
-          <md-input-container class="flex">
+        <div layout-gt-sm="row" ng-if="($ctrl.advancedMode && $ctrl.ApiPrimaryOwnerModeService.isHybrid() && $ctrl.parent.poGroups && $ctrl.parent.poGroups.length > 0) || $ctrl.ApiPrimaryOwnerModeService.isGroupOnly()">
+          <md-input-container ng-if="$ctrl.ApiPrimaryOwnerModeService.isHybrid()" class="md-block" flex-gt-sm>
+            <md-switch ng-model="$ctrl.useGroupAsPrimaryOwner" aria-label="Use a group as primary owner" flex>
+              Use a group as the primary owner
+            </md-switch>
+          </md-input-container>
+          <md-input-container  class="md-block" flex-gt-sm>
+            <label>Primary Owner Group</label>
+            <md-select name="poGroupOwner" ng-model="$ctrl.parent.api.primaryOwner" ng-disabled="!$ctrl.useGroupAsPrimaryOwner" ng-required="$ctrl.ApiPrimaryOwnerModeService.isGroupOnly()">
+              <md-option ng-repeat="group in $ctrl.parent.poGroups" ng-value="{id: group.id, type: 'GROUP'}">{{group.name}}</md-option>
+            </md-select>
+            <div class="hint">Select the group that will be the primary owner</div>
+            <div ng-messages="apiGeneralForm.poGroupOwner.$error">
+              <div ng-message="required">A primary owner group is required. Check that you belong to at least one group with an API primary owner member.</div>
+            </div>
+          </md-input-container>
+        </div>
+
+        <div layout-gt-sm="row" ng-if="$ctrl.advancedMode && $ctrl.parent.attachableGroups && $ctrl.parent.attachableGroups.length > 0">
+          <md-input-container  class="md-block" flex-gt-sm>
             <label>Groups</label>
             <md-select ng-model="$ctrl.parent.api.groups" multiple>
-              <md-option ng-repeat="group in $ctrl.parent.groups" ng-value="group">{{group.name}}</md-option>
+              <md-option ng-repeat="group in $ctrl.parent.attachableGroups" ng-value="group">{{group.name}}</md-option>
             </md-select>
             <div class="hint">Groups that will be able to access the API.</div>
           </md-input-container>
         </div>
-
 
         <md-step-actions layout="row">
           <div flex>
@@ -90,7 +114,7 @@
           <div layout="row" flex layout-align="end top">
             <md-button type="submit" ng-disabled="apiGeneralForm.$invalid">NEXT</md-button>
           </div>
-      </md-step-actions>
+        </md-step-actions>
       </form>
     </md-content>
   </md-step-body>

--- a/src/management/api/creation/steps/api-creation.controller.ts
+++ b/src/management/api/creation/steps/api-creation.controller.ts
@@ -16,16 +16,19 @@
 import * as _ from 'lodash';
 import ApiService from '../../../../services/api.service';
 import NotificationService from '../../../../services/notification.service';
-import {StateService} from '@uirouter/core';
+import { StateService } from '@uirouter/core';
 import NewApiController, {
   getDefinitionVersionDescription,
   getDefinitionVersionTitle
 } from '../newApiPortal.controller';
+import UserService from '../../../../services/user.service';
 
 class ApiCreationController {
 
   api: any;
   selectedTenants: any[];
+  attachableGroups: any[];
+  poGroups: any[];
 
   private parent: NewApiController;
   private vm: {
@@ -71,6 +74,7 @@ class ApiCreationController {
               private $window,
               private ApiService: ApiService,
               private NotificationService: NotificationService,
+              private UserService: UserService,
               private $state: StateService,
               private Constants: any,
               private $rootScope) {
@@ -118,6 +122,17 @@ class ApiCreationController {
 
     // init documentation settings
     this.initDocumentationSettings();
+  }
+
+  $onInit = () => {
+    this.attachableGroups = this.groups.filter(
+      (group) => group.apiPrimaryOwner == null
+    );
+    this.UserService.getUserGroups(this.UserService.currentUser.id)
+      .then((response) => {
+        this.poGroups = this.groups.filter(
+          (group) => group.apiPrimaryOwner != null && response.data.some(userGroup => userGroup.id === group.id));
+      });
   }
 
   /*

--- a/src/management/api/portal/general/apiPortal.controller.ts
+++ b/src/management/api/portal/general/apiPortal.controller.ts
@@ -24,6 +24,8 @@ class ApiPortalController {
   private initialApi: any;
   private api: any;
   private groups: any;
+  private attachableGroups: any;
+  private attachedGroups: any;
   private categories: any;
   private tags: any;
   private tenants: any;
@@ -113,6 +115,8 @@ class ApiPortalController {
 
     this.tags = resolvedTags;
     this.groups = resolvedGroups;
+    this.attachableGroups = resolvedGroups.filter(group => group.apiPrimaryOwner == null);
+    this.attachedGroups = this.api.groups.map(groupId => this.getGroup(groupId)).filter(group => group.apiPrimaryOwner == null);
 
     this.headers = [
       'Accept', 'Accept-Charset', 'Accept-Encoding', 'Accept-Language', 'Accept-Ranges', 'Access-Control-Allow-Credentials',
@@ -503,6 +507,7 @@ class ApiPortalController {
       }
     });
   }
+
 }
 
 export default ApiPortalController;

--- a/src/management/api/portal/userGroupAccess/groups/groups.html
+++ b/src/management/api/portal/userGroupAccess/groups/groups.html
@@ -26,16 +26,16 @@
 
   <md-input-container permission permission-only="'api-definition-u'" class="flex">
     <label>Groups</label>
-    <md-select ng-model="portalCtrl.api.groups" multiple ng-disabled="!(portalCtrl.groups && portalCtrl.groups.length > 0)">
-      <md-option ng-repeat="group in portalCtrl.groups" ng-value="group.id">
+    <md-select ng-model="portalCtrl.api.groups" multiple ng-disabled="!(portalCtrl.attachableGroups && portalCtrl.attachableGroups.length > 0)">
+      <md-option ng-repeat="group in portalCtrl.attachableGroups" ng-value="group.id">
         {{group.name}}
       </md-option>
     </md-select>
   </md-input-container>
   <div permission permission-except="'api-definition-u'" layout="column">
     <label>Groups</label>
-    <md-chips permission permission-except="'api-definition-u'" readonly="true" ng-model="portalCtrl.api.groups">
-      <md-chip-template>{{portalCtrl.getGroup($chip).name}}</md-chip-template>
+    <md-chips permission permission-except="'api-definition-u'" readonly="true" ng-model="portalCtrl.attachedGroups">
+      <md-chip-template>{{$chip.name}}</md-chip-template>
     </md-chips>
   </div>
   <div class="md-actions gravitee-api-save-button" layout="row">

--- a/src/management/api/portal/userGroupAccess/members/members.html
+++ b/src/management/api/portal/userGroupAccess/members/members.html
@@ -84,7 +84,9 @@
   </div>
 
   <div class="gv-form" ng-repeat="grp in apiMembersCtrl.groupIdsWithMembers">
-    <h2>{{apiMembersCtrl.groupMembers[grp].length}} members inherited from group "{{apiMembersCtrl.groupById[grp].name}}"</h2>
+    <h2>{{apiMembersCtrl.groupMembers[grp].length}} members inherited from group "{{apiMembersCtrl.groupById[grp].name}}"
+      <span ng-if="apiMembersCtrl.groupById[grp].primary_owner" flex class="badge" style="background-color: #039be5">Primary Owner</span>
+    </h2>
     <div class="gv-form-content" layout="column">
       <div layout="row" layout-align="start end">
         <div style="margin-bottom: 5px;" ng-model="apiMembersCtrl.displayGroups[grp]"

--- a/src/management/api/portal/userGroupAccess/transferOwnership/transferOwnership.html
+++ b/src/management/api/portal/userGroupAccess/transferOwnership/transferOwnership.html
@@ -20,31 +20,90 @@
 
   <div class="gv-form">
     <h2></h2>
-    <div class="gv-form-content" layout="column" layout-align="start stretch">
-      <div ng-if="apiTransferOwnershipCtrl.isAllowedToTransferOwnership()">
-        <p>
-          Give full access to this API to an other user.
-        </p>
-        <gv-user-autocomplete
-          users-selected="apiTransferOwnershipCtrl.usersSelected"
-          place-holder="'Select a user'"
-          single-user="true"
-          user-filter-fn="apiTransferOwnershipCtrl.userFilterFn"
-          default-users-list="apiTransferOwnershipCtrl.defaultUsersList"
-        >
-        </gv-user-autocomplete>
-        <br/>
-        <md-input-container class="md-block">
+    <div
+      class="gv-form-content"
+      layout="column"
+      layout-align="start stretch"
+      ng-if="apiTransferOwnershipCtrl.isAllowedToTransferOwnership()"
+    >
+      <p ng-if="apiTransferOwnershipCtrl.ApiPrimaryOwnerModeService.isHybrid()">Give full access to this API to another user or group.</p>
+      <p ng-if="apiTransferOwnershipCtrl.ApiPrimaryOwnerModeService.isUserOnly()">Give full access to this API to another user.</p>
+      <p ng-if="apiTransferOwnershipCtrl.ApiPrimaryOwnerModeService.isGroupOnly()">Give full access to this API to another group.</p>
+      <div layout="column" flex>
+        <div layout="row " layout-align="center center" layout-padding="5px" flex ng-if="apiTransferOwnershipCtrl.ApiPrimaryOwnerModeService.isHybrid() && apiTransferOwnershipCtrl.poGroups && apiTransferOwnershipCtrl.poGroups.length > 0">
+          <md-radio-group ng-model="apiTransferOwnershipCtrl.useGroupAsPrimaryOwner" flex>
+            <div layout="row" layout-align="start center">
+              <md-radio-button ng-value="false" aria-label="false" style="margin-bottom: initial"></md-radio-button>
+              <gv-user-autocomplete
+                users-selected="apiTransferOwnershipCtrl.usersSelected"
+                place-holder="'Select a user'"
+                single-user="true"
+                user-filter-fn="apiTransferOwnershipCtrl.userFilterFn"
+                default-users-list="apiTransferOwnershipCtrl.defaultUsersList"
+                disabled="apiTransferOwnershipCtrl.useGroupAsPrimaryOwner"
+                flex
+              >
+              </gv-user-autocomplete>
+            </div>
+            <div layout="row" layout-align="start center">
+              <md-radio-button ng-value="true" aria-label="true" style="margin-bottom: initial"></md-radio-button>
+              <md-input-container flex>
+                <label>Primary Owner Group</label>
+                <md-select
+                  ng-model="apiTransferOwnershipCtrl.newPrimaryOwnerGroup"
+                  ng-disabled="!apiTransferOwnershipCtrl.useGroupAsPrimaryOwner"
+                >
+                  <md-option ng-value=""></md-option>
+                  <md-option ng-repeat="group in apiTransferOwnershipCtrl.poGroups" ng-value="group.id">{{group.name}}</md-option>
+                </md-select>
+              </md-input-container>
+            </div>
+          </md-radio-group>
+        </div>
+        <div layout="row " layout-align="center center" layout-padding="5px" flex ng-if="(apiTransferOwnershipCtrl.ApiPrimaryOwnerModeService.isHybrid() && !(apiTransferOwnershipCtrl.poGroups && apiTransferOwnershipCtrl.poGroups.length > 0)) || apiTransferOwnershipCtrl.ApiPrimaryOwnerModeService.isUserOnly()">
+          <gv-user-autocomplete
+            users-selected="apiTransferOwnershipCtrl.usersSelected"
+            place-holder="'Select a user'"
+            single-user="true"
+            user-filter-fn="apiTransferOwnershipCtrl.userFilterFn"
+            default-users-list="apiTransferOwnershipCtrl.defaultUsersList"
+            flex
+          >
+          </gv-user-autocomplete>
+        </div>
+        <div layout="row " layout-align="center center" layout-padding="5px" flex ng-if="apiTransferOwnershipCtrl.ApiPrimaryOwnerModeService.isGroupOnly() && apiTransferOwnershipCtrl.poGroups && apiTransferOwnershipCtrl.poGroups.length > 0">
+          <md-input-container flex>
+            <label>Primary Owner Group</label>
+            <md-select
+              ng-model="apiTransferOwnershipCtrl.newPrimaryOwnerGroup"
+              ng-disabled="!apiTransferOwnershipCtrl.useGroupAsPrimaryOwner"
+            >
+              <md-option ng-value=""></md-option>
+              <md-option ng-repeat="group in apiTransferOwnershipCtrl.poGroups" ng-value="group.id">{{group.name}}</md-option>
+            </md-select>
+          </md-input-container>
+        </div>
+        <div layout="row " layout-align="center center" layout-padding="5px" flex ng-if="apiTransferOwnershipCtrl.ApiPrimaryOwnerModeService.isGroupOnly() && !(apiTransferOwnershipCtrl.poGroups && apiTransferOwnershipCtrl.poGroups.length > 0)">
+          <md-input-container flex>
+            <div>You must belong to at least one group with an API primary owner member (which is not the current primary owner).</div>
+          </md-input-container>
+        </div>
+
+        <br />
+        <md-input-container class="md-block" flex ng-if="apiTransferOwnershipCtrl.api.owner.type.toUpperCase() === 'USER'">
           <label>New role for current Primary Owner</label>
           <md-select ng-model="apiTransferOwnershipCtrl.newPORole">
             <md-option ng-value="role" ng-repeat="role in apiTransferOwnershipCtrl.newPORoles">{{role.name}}</md-option>
           </md-select>
         </md-input-container>
-
-        <div class="md-actions gravitee-api-save-button" layout="row">
-          <md-button ng-disabled="!apiTransferOwnershipCtrl.usersSelected || !apiTransferOwnershipCtrl.usersSelected[0]" class="md-primary md-raised" ng-click="apiTransferOwnershipCtrl.showTransferOwnershipConfirm($event)">Transfer</md-button>
-        </div>
-
+      </div>
+      <div class="md-actions gravitee-api-save-button" layout="row" flex>
+        <md-button
+          ng-disabled="!(apiTransferOwnershipCtrl.usersSelected && apiTransferOwnershipCtrl.usersSelected[0]) && !apiTransferOwnershipCtrl.newPrimaryOwnerGroup"
+          class="md-primary md-raised"
+          ng-click="apiTransferOwnershipCtrl.showTransferOwnershipConfirm($event)"
+        >Transfer</md-button
+        >
       </div>
     </div>
   </div>

--- a/src/management/configuration/groups/group/addMember.dialog.html
+++ b/src/management/configuration/groups/group/addMember.dialog.html
@@ -25,7 +25,7 @@
                  class="md-no-underline" ng-disabled="!$ctrl.canChangeDefaultApiRole()">
         <md-option ng-repeat="role in $ctrl.apiRoles"
                    ng-value="role.name"
-                   ng-disabled="role.system">
+                   ng-disabled="$ctrl.isApiRoleDisabled(role)">
           {{role.name}}
         </md-option>
       </md-select>

--- a/src/management/configuration/groups/group/addMemberDialog.controller.ts
+++ b/src/management/configuration/groups/group/addMemberDialog.controller.ts
@@ -18,6 +18,7 @@ import * as _ from 'lodash';
 export class Role {
   default: boolean;
   name: string;
+  system: boolean;
 }
 
 function DialogAddGroupMemberController(
@@ -28,7 +29,8 @@ function DialogAddGroupMemberController(
   apiRoles: Role[],
   applicationRoles: Role[],
   canChangeDefaultApiRole,
-  canChangeDefaultApplicationRole
+  canChangeDefaultApplicationRole,
+  isApiRoleDisabled
   ) {
   'ngInject';
 
@@ -44,6 +46,7 @@ function DialogAddGroupMemberController(
 
   this.canChangeDefaultApiRole = canChangeDefaultApiRole;
   this.canChangeDefaultApplicationRole = canChangeDefaultApplicationRole;
+  this.isApiRoleDisabled = isApiRoleDisabled;
 
   this.hide = () => {
     $mdDialog.cancel();
@@ -71,6 +74,7 @@ function DialogAddGroupMemberController(
   this.invalid = () => {
     return (!this.defaultApiRole && !this.defaultApplicationRole) || (this.usersSelected.length === 0);
   };
+
 }
 
 export default DialogAddGroupMemberController;

--- a/src/management/configuration/groups/group/group.html
+++ b/src/management/configuration/groups/group/group.html
@@ -16,310 +16,380 @@
 
 -->
 <div class="gv-forms" layout="column">
-    <div class="gv-forms-header">
-        <h1 ng-if="$ctrl.updateMode">{{$ctrl.group.name}}</h1>
-        <h1 ng-if="!$ctrl.updateMode">Create a group</h1>
-        <a ui-sref="management.settings.groups.list">Back to groups</a>
+  <div class="gv-forms-header">
+    <h1 ng-if="$ctrl.updateMode">{{$ctrl.group.name}}</h1>
+    <h1 ng-if="!$ctrl.updateMode">Create a group</h1>
+    <a ui-sref="management.settings.groups.list">Back to groups</a>
+  </div>
+
+  <form name="formGroup" class="gv-form" ng-submit="$ctrl.update()">
+    <h2>General</h2>
+    <div class="gv-form-content" layout="column">
+      <div layout-gt-sm="row">
+        <md-input-container class="md-block" flex-gt-sm>
+          <label>Name</label>
+          <input ng-model="$ctrl.group.name" type="text" required name="name" maxlength="50" />
+          <div class="hint" ng-if="$ctrl.formGroup.name.$valid || $ctrl.formGroup.name.$pristine">Group Name</div>
+          <div ng-messages="$ctrl.formGroup.name.$error">
+            <div ng-message="required">Group name is required.</div>
+            <div ng-message="md-maxlength">The group name has to be less than 50 characters long.</div>
+          </div>
+        </md-input-container>
+      </div>
     </div>
 
-    <form name="formGroup" class="gv-form" ng-submit="$ctrl.update()">
-      <h2>General</h2>
-      <div class="gv-form-content" layout="column">
-        <div layout-gt-sm="row">
-          <md-input-container class="md-block" flex-gt-sm>
-            <label>Name</label>
-            <input ng-model="$ctrl.group.name" type="text" required name="name" maxlength="50">
-            <div class="hint" ng-if="$ctrl.formGroup.name.$valid || $ctrl.formGroup.name.$pristine">Group Name</div>
-            <div ng-messages="$ctrl.formGroup.name.$error">
-              <div ng-message="required">Group name is required.</div>
-              <div ng-message="md-maxlength">The group name has to be less than 50 characters long.</div>
-            </div>
+    <h2>Roles & Members</h2>
+    <div class="gv-form-content" layout="column">
+      <div layout="row" ng-if="$ctrl.updateMode">
+        <div layout="row" flex="50">
+          <b style="margin: 26px 10px 26px 0">Default API Role</b>
+          <md-select
+            placeholder="Default API Role"
+            class="gv-input-number"
+            ng-model="$ctrl.selectedApiRole"
+            aria-label="Default API Role"
+            ng-disabled="!$ctrl.canChangeDefaultApiRole()"
+          >
+            <md-option ng-value="role.name" ng-repeat="role in $ctrl.apiRoles" ng-disabled="role.system">{{role.name}} </md-option>
+          </md-select>
+        </div>
+        <div layout="row" flex="50">
+          <b style="margin: 26px 10px 26px 0">Default Application Role</b>
+          <md-select
+            placeholder="Default Application Role"
+            ng-model="$ctrl.selectedApplicationRole"
+            class="gv-input-number"
+            aria-label="Default Application Role"
+            ng-disabled="!$ctrl.canChangeDefaultApplicationRole()"
+          >
+            <md-option ng-value="role.name" ng-repeat="role in $ctrl.applicationRoles" ng-disabled="role.system">{{role.name}} </md-option>
+          </md-select>
+        </div>
+      </div>
+
+      <div permission permission-only="'environment-group-u'">
+        <div layout="column">
+          <md-input-container class="gv-input-number">
+            <label>Max members (default unlimited)</label>
+            <input ng-model="$ctrl.group.max_invitation" type="number" min="0" max="99999" />
           </md-input-container>
-        </div>
-      </div>
-
-      <h2>Roles & Members</h2>
-      <div class="gv-form-content" layout="column">
-        <div layout="row" ng-if="$ctrl.updateMode">
-          <div layout="row" flex="50">
-            <b style="margin: 26px 10px 26px 0">Default API Role</b>
-            <md-select placeholder="Default API Role" class="gv-input-number"
-              ng-model="$ctrl.selectedApiRole" aria-label="Default API Role" ng-disabled="!$ctrl.canChangeDefaultApiRole()">
-              <md-option ng-value="role.name"
-                         ng-repeat="role in $ctrl.apiRoles"
-                         ng-disabled="role.system">{{role.name}}</md-option>
-            </md-select>
-          </div>
-          <div layout="row" flex="50">
-            <b style="margin: 26px 10px 26px 0">Default Application Role</b>
-            <md-select placeholder="Default Application Role" ng-model="$ctrl.selectedApplicationRole" class="gv-input-number"
-                       aria-label="Default Application Role" ng-disabled="!$ctrl.canChangeDefaultApplicationRole()">
-              <md-option ng-value="role.name"
-                         ng-repeat="role in $ctrl.applicationRoles"
-                         ng-disabled="role.system">{{role.name}}</md-option>
-            </md-select>
-          </div>
-        </div>
-
-        <div permission permission-only="'environment-group-u'">
-          <div layout="column">
-            <md-input-container class="gv-input-number">
-              <label>Max members (default unlimited)</label>
-              <input ng-model="$ctrl.group.max_invitation" type="number" min="0" max="99999">
-            </md-input-container>
-            <md-checkbox ng-model="$ctrl.group.system_invitation" aria-label="Allows system invitation" class="md-align-top-left" flex>
-              Allows invitation via user search
-            </md-checkbox>
-            <md-checkbox ng-model="$ctrl.group.email_invitation" aria-label="Allows email invitation" class="md-align-top-left" flex>
-              Allows email invitation
-            </md-checkbox>
-            <md-checkbox ng-model="$ctrl.group.lock_api_role" ng-true-value="false" ng-false-value="true" aria-label="Change default API role" class="md-align-top-left" flex>
-              Allows the group admin to change the API role
-            </md-checkbox>
-            <md-checkbox ng-model="$ctrl.group.lock_application_role" ng-true-value="false" ng-false-value="true" aria-label="Change default Application role" class="md-align-top-left" flex>
-              Allows the group admin to change the application role
-            </md-checkbox>
-            <md-checkbox ng-model="$ctrl.group.disable_membership_notifications" ng-true-value="false" ng-false-value="true" aria-label="Enables notifications when members are added to this group" class="md-align-top-left" flex>
-              Enables notifications when members are added to this group
-            </md-checkbox>
-          </div>
-        </div>
-      </div>
-
-      <h2>Associations</h2>
-      <div class="gv-form-content" layout="column">
-        <div layout="column" style="margin-bottom: 10px;">
-          <md-checkbox
-                ng-model="$ctrl.apiByDefault"
-                ng-click="$event.stopPropagation()"
-                aria-label="Associate to every new API"
-                class="md-primary md-align-top-left"
-                flex>
-                Associate automatically to every new API
+          <md-checkbox ng-model="$ctrl.group.system_invitation" aria-label="Allows system invitation" class="md-align-top-left" flex>
+            Allows invitation via user search
+          </md-checkbox>
+          <md-checkbox ng-model="$ctrl.group.email_invitation" aria-label="Allows email invitation" class="md-align-top-left" flex>
+            Allows email invitation
           </md-checkbox>
           <md-checkbox
-                ng-model="$ctrl.applicationByDefault"
-                aria-label="Associate to every new application"
-                class="md-primary md-align-top-left"
-                flex>
-                Associate automatically to every new application
+            ng-model="$ctrl.group.lock_api_role"
+            ng-true-value="false"
+            ng-false-value="true"
+            aria-label="Change default API role"
+            class="md-align-top-left"
+            flex
+          >
+            Allows the group admin to change the API role
+          </md-checkbox>
+          <md-checkbox
+            ng-model="$ctrl.group.lock_application_role"
+            ng-true-value="false"
+            ng-false-value="true"
+            aria-label="Change default Application role"
+            class="md-align-top-left"
+            flex
+          >
+            Allows the group admin to change the application role
+          </md-checkbox>
+          <md-checkbox
+            ng-model="$ctrl.group.disable_membership_notifications"
+            ng-true-value="false"
+            ng-false-value="true"
+            aria-label="Enables notifications when members are added to this group"
+            class="md-align-top-left"
+            flex
+          >
+            Enables notifications when members are added to this group
           </md-checkbox>
         </div>
-        <div class="md-actions gravitee-api-save-button" layout="row" ng-if="$ctrl.updateMode">
-          <md-button
-                     aria-label="Associate to existing APIs"
-                     ng-click="$ctrl.associateToApis()"
-                     class="md-actions md-raised md-primary">
-            Associate to existing APIs
-          </md-button>
-
-          <md-button
-            aria-label="Associate to existing applications"
-            ng-click="$ctrl.associateToApplications()"
-            class="md-actions md-raised md-primary">
-            Associate to existing applications
-          </md-button>
-        </div>
       </div>
+    </div>
 
-      <h2>Actions</h2>
-      <div class="gv-form-content" layout="column">
-        <div class="md-actions gravitee-api-save-button" layout="row" ng-if="$ctrl.canSave()">
-          <md-button ng-if="$ctrl.updateMode" class="md-raised md-primary" type="submit"
-                     ng-disabled="formGroup.$invalid || formGroup.$pristine"
-                     permission permission-only="['environment-group-u']">
-            Update
-          </md-button>
-
-          <md-button ng-if="!$ctrl.updateMode" class="md-raised md-primary" type="submit"
-                     ng-disabled="formGroup.$invalid || formGroup.$pristine"
-                     permission permission-only="['environment-group-c']">
-            Create
-          </md-button>
-
-          <md-button class="md-raised" type="button" ng-click="$ctrl.reset()" ng-disabled="formGroup.$invalid || formGroup.$pristine">
-            Reset
-          </md-button>
-        </div>
+    <h2>Associations</h2>
+    <div class="gv-form-content" layout="column">
+      <div layout="column" style="margin-bottom: 10px">
+        <md-checkbox
+          ng-model="$ctrl.apiByDefault"
+          ng-click="$event.stopPropagation()"
+          aria-label="Associate to every new API"
+          class="md-primary md-align-top-left"
+          flex
+        >
+          Associate automatically to every new API
+        </md-checkbox>
+        <md-checkbox
+          ng-model="$ctrl.applicationByDefault"
+          aria-label="Associate to every new application"
+          class="md-primary md-align-top-left"
+          flex
+        >
+          Associate automatically to every new application
+        </md-checkbox>
       </div>
+      <div class="md-actions gravitee-api-save-button" layout="row" ng-if="$ctrl.updateMode">
+        <md-button aria-label="Associate to existing APIs" ng-click="$ctrl.associateToApis()" class="md-actions md-raised md-primary">
+          Associate to existing APIs
+        </md-button>
 
-    </form>
+        <md-button
+          aria-label="Associate to existing applications"
+          ng-click="$ctrl.associateToApplications()"
+          class="md-actions md-raised md-primary"
+        >
+          Associate to existing applications
+        </md-button>
+      </div>
+    </div>
 
-    <div class="gv-form" ng-if="$ctrl.updateMode">
-        <h2>Dependents</h2>
-        <div class="gv-form-content" layout="column">
-          <md-tabs md-dynamic-height>
-            <md-tab md-on-select="currentTab='users'">
-              <md-tab-label>Members</md-tab-label>
-              <md-tab-body>
-              <div style="margin: 16px 0 8px;">You can manage all members of this group.
-                <span permission permission-except="'environment-group-u'" ng-if="$ctrl.group.max_invitation"> Limited to {{$ctrl.group.max_invitation}} members.</span>
-                <div ng-if="$ctrl.hasGroupAdmin() && !$ctrl.group.system_invitation && !$ctrl.group.email_invitation" style="font-weight: bold;">
-                  Enable email invitation and/or user search to allow the group administrator to add users.
-                </div>
+    <h2>Actions</h2>
+    <div class="gv-form-content" layout="column">
+      <div class="md-actions gravitee-api-save-button" layout="row" ng-if="$ctrl.canSave()">
+        <md-button
+          ng-if="$ctrl.updateMode"
+          class="md-raised md-primary"
+          type="submit"
+          ng-disabled="formGroup.$invalid || formGroup.$pristine"
+          permission
+          permission-only="['environment-group-u']"
+        >
+          Update
+        </md-button>
+
+        <md-button
+          ng-if="!$ctrl.updateMode"
+          class="md-raised md-primary"
+          type="submit"
+          ng-disabled="formGroup.$invalid || formGroup.$pristine"
+          permission
+          permission-only="['environment-group-c']"
+        >
+          Create
+        </md-button>
+
+        <md-button class="md-raised" type="button" ng-click="$ctrl.reset()" ng-disabled="formGroup.$invalid || formGroup.$pristine">
+          Reset
+        </md-button>
+      </div>
+    </div>
+  </form>
+
+  <div class="gv-form" ng-if="$ctrl.updateMode">
+    <h2>Dependents</h2>
+    <div class="gv-form-content" layout="column">
+      <md-tabs md-dynamic-height>
+        <md-tab md-on-select="currentTab='users'">
+          <md-tab-label>Members</md-tab-label>
+          <md-tab-body>
+            <div style="margin: 16px 0 8px">
+              You can manage all members of this group.
+              <span permission permission-except="'environment-group-u'" ng-if="$ctrl.group.max_invitation">
+                Limited to {{$ctrl.group.max_invitation}} members.</span
+              >
+              <div
+                ng-if="$ctrl.hasGroupAdmin() && !$ctrl.group.system_invitation && !$ctrl.group.email_invitation"
+                style="font-weight: bold"
+              >
+                Enable email invitation and/or user search to allow the group administrator to add users.
               </div>
-              <md-table-container>
-                <table md-table ng-init="orderGrp = 'displayName'">
-                  <thead md-head md-order="orderGrp">
+            </div>
+            <md-table-container>
+              <table md-table ng-init="orderGrp = 'displayName'">
+                <thead md-head md-order="orderGrp">
+                <tr md-row>
+                  <th md-column width="22%" md-order-by="displayName">Name</th>
+                  <th md-column width="22%">Group Admin</th>
+                  <th md-column width="22%">API Role</th>
+                  <th md-column width="22%">Application Role</th>
+                  <th md-column width="12%"></th>
+                </tr>
+                </thead>
+                <tbody md-body>
+                <tr style="height: 30px" ng-if="$ctrl.members.length === 0">
+                  <td md-cell style="text-align: center" colspan="5">None.</td>
+                </tr>
+                <tr md-row ng-repeat="member in $ctrl.members | orderBy: orderGrp">
+                  <td md-cell>{{member.displayName}}</td>
+                  <td md-cell>
+                    <md-checkbox
+                      ng-model="member.roles['GROUP']"
+                      ng-true-value="'ADMIN'"
+                      ng-false-value="''"
+                      ng-change="$ctrl.updateRole(member)"
+                      aria-label="Administrator of this group"
+                    >
+                    </md-checkbox>
+                  </td>
+                  <td md-cell>
+                    <md-select
+                      ng-model="member.roles['API']"
+                      aria-label="API Role"
+                      ng-change="$ctrl.updateRole(member)"
+                      ng-disabled="!$ctrl.canChangeDefaultApiRole()"
+                    >
+                      <md-option ng-value="role.name" ng-repeat="role in $ctrl.apiRoles" ng-disabled="$ctrl.isApiRoleDisabled(role)"
+                      >{{role.name}}</md-option
+                      >
+                    </md-select>
+                  </td>
+                  <td md-cell>
+                    <md-select
+                      ng-model="member.roles['APPLICATION']"
+                      aria-label="Application Role"
+                      ng-change="$ctrl.updateRole(member)"
+                      ng-disabled="!$ctrl.canChangeDefaultApplicationRole()"
+                    >
+                      <md-option ng-value="role.name" ng-repeat="role in $ctrl.applicationRoles" ng-disabled="role.system"
+                      >{{role.name}}</md-option
+                      >
+                    </md-select>
+                  </td>
+                  <td md-cell ng-click="$event.stopPropagation()">
+                    <div layout="row" layout-align="end center">
+                        <span ng-if="$ctrl.group.manageable">
+                          <md-tooltip md-direction="top">delete</md-tooltip>
+                          <ng-md-icon icon="delete" ng-click="$ctrl.removeUser($event, member)" aria-label="delete-user"></ng-md-icon>
+                        </span>
+                    </div>
+                  </td>
+                </tr>
+                </tbody>
+              </table>
+              <div ng-if="$ctrl.invitations.length > 0">
+                <hr />
+                <h3 style="color: red">Pending invitations</h3>
+                <table md-table ng-init="orderInvitation = 'email'">
+                  <thead md-head md-order="orderInvitation">
                   <tr md-row>
-                    <th md-column width="22%" md-order-by="displayName">Name</th>
-                    <th md-column width="22%">Group Admin</th>
-                    <th md-column width="22%">API Role</th>
-                    <th md-column width="22%">Application Role</th>
-                    <th md-column width="12%"></th>
+                    <th md-column md-order-by="email">Email</th>
+                    <th md-column>API Role</th>
+                    <th md-column>Application Role</th>
+                    <th md-column md-order-by="created_at">Invitation date</th>
+                    <th md-column></th>
                   </tr>
                   </thead>
                   <tbody md-body>
-                  <tr style="height: 30px;" ng-if="$ctrl.members.length === 0">
-                    <td md-cell style="text-align: center;" colspan="5">None.</td>
-                  </tr>
-                  <tr md-row
-                      ng-repeat="member in $ctrl.members | orderBy: orderGrp">
-                    <td md-cell>{{member.displayName}}</td>
+                  <tr md-row ng-repeat="invitation in $ctrl.invitations | orderBy: orderInvitation">
+                    <td md-cell>{{invitation.email}}</td>
                     <td md-cell>
-                      <md-checkbox ng-model="member.roles['GROUP']"
-                                   ng-true-value="'ADMIN'"
-                                   ng-false-value="''"
-                                   ng-change="$ctrl.updateRole(member)"
-                                   aria-label="Administrator of this group">
-                      </md-checkbox>
-                    </td>
-                    <td md-cell>
-                      <md-select ng-model="member.roles['API']"
-                                 aria-label="API Role"
-                                 ng-change="$ctrl.updateRole(member)" ng-disabled="!$ctrl.canChangeDefaultApiRole()">
-                        <md-option ng-value="role.name" ng-repeat="role in $ctrl.apiRoles" ng-disabled="role.system">{{role.name}}</md-option>
+                      <md-select
+                        ng-model="invitation.api_role"
+                        aria-label="API Role"
+                        ng-change="$ctrl.updateInvitation(invitation)"
+                        ng-disabled="!$ctrl.canChangeDefaultApiRole()"
+                      >
+                        <md-option ng-value="role.name" ng-repeat="role in $ctrl.apiRoles" ng-disabled="$ctrl.isApiRoleDisabled(role)"
+                        >{{role.name}}</md-option
+                        >
                       </md-select>
                     </td>
                     <td md-cell>
-                      <md-select ng-model="member.roles['APPLICATION']"
-                                 aria-label="Application Role"
-                                 ng-change="$ctrl.updateRole(member)" ng-disabled="!$ctrl.canChangeDefaultApplicationRole()">
-                        <md-option ng-value="role.name" ng-repeat="role in $ctrl.applicationRoles" ng-disabled="role.system">{{role.name}}</md-option>
+                      <md-select
+                        ng-model="invitation.application_role"
+                        aria-label="Application Role"
+                        ng-change="$ctrl.updateInvitation(invitation)"
+                        ng-disabled="!$ctrl.canChangeDefaultApplicationRole()"
+                      >
+                        <md-option ng-value="role.name" ng-repeat="role in $ctrl.applicationRoles" ng-disabled="role.system"
+                        >{{role.name}}</md-option
+                        >
                       </md-select>
                     </td>
+                    <td md-cell>{{invitation.created_at | date}}</td>
                     <td md-cell ng-click="$event.stopPropagation()">
                       <div layout="row" layout-align="end center">
-                                <span ng-if="$ctrl.group.manageable">
-                                    <md-tooltip md-direction="top">delete</md-tooltip>
-                                    <ng-md-icon icon="delete" ng-click="$ctrl.removeUser($event, member)" aria-label="delete-user"></ng-md-icon>
-                                </span>
+                          <span ng-if="$ctrl.group.manageable">
+                            <md-tooltip md-direction="top">delete</md-tooltip>
+                            <ng-md-icon
+                              icon="delete"
+                              ng-click="$ctrl.removeInvitation($event, invitation)"
+                              aria-label="delete-user"
+                            ></ng-md-icon>
+                          </span>
                       </div>
                     </td>
                   </tr>
                   </tbody>
                 </table>
-                <div ng-if="$ctrl.invitations.length > 0">
-                  <hr>
-                  <h3 style="color: red;">Pending invitations</h3>
-                  <table md-table ng-init="orderInvitation = 'email'">
-                    <thead md-head md-order="orderInvitation">
-                    <tr md-row>
-                      <th md-column md-order-by="email">Email</th>
-                      <th md-column>API Role</th>
-                      <th md-column>Application Role</th>
-                      <th md-column md-order-by="created_at">Invitation date</th>
-                      <th md-column></th>
-                    </tr>
-                    </thead>
-                    <tbody md-body>
-                    <tr md-row ng-repeat="invitation in $ctrl.invitations | orderBy: orderInvitation">
-                      <td md-cell>{{invitation.email}}</td>
-                      <td md-cell>
-                        <md-select ng-model="invitation.api_role"
-                                   aria-label="API Role"
-                                   ng-change="$ctrl.updateInvitation(invitation)" ng-disabled="!$ctrl.canChangeDefaultApiRole()">
-                          <md-option ng-value="role.name" ng-repeat="role in $ctrl.apiRoles" ng-disabled="role.system">{{role.name}}</md-option>
-                        </md-select>
-                      </td>
-                      <td md-cell>
-                        <md-select ng-model="invitation.application_role"
-                                   aria-label="Application Role"
-                                   ng-change="$ctrl.updateInvitation(invitation)" ng-disabled="!$ctrl.canChangeDefaultApplicationRole()">
-                          <md-option ng-value="role.name" ng-repeat="role in $ctrl.applicationRoles" ng-disabled="role.system">{{role.name}}</md-option>
-                        </md-select>
-                      </td>
-                      <td md-cell>{{invitation.created_at | date}}</td>
-                      <td md-cell ng-click="$event.stopPropagation()">
-                        <div layout="row" layout-align="end center">
-                            <span ng-if="$ctrl.group.manageable">
-                                <md-tooltip md-direction="top">delete</md-tooltip>
-                                <ng-md-icon icon="delete" ng-click="$ctrl.removeInvitation($event, invitation)" aria-label="delete-user"></ng-md-icon>
-                            </span>
-                        </div>
-                      </td>
-                    </tr>
-                    </tbody>
-                  </table>
-                </div>
-                </md-table-container>
+              </div>
             </md-table-container>
-        </md-tab-body>
-    </md-tab>
-    <md-tab md-on-select="currentTab='apis'; $ctrl.loadGroupApis();">
-        <md-tab-label>APIs</md-tab-label>
-        <md-tab-body>
-            <div style="margin: 16px 0 8px;">Here is the list of all APIs of this group.</div>
+          </md-tab-body>
+        </md-tab>
+        <md-tab md-on-select="currentTab='apis'; $ctrl.loadGroupApis();">
+          <md-tab-label>APIs</md-tab-label>
+          <md-tab-body>
+            <div style="margin: 16px 0 8px">Here is the list of all APIs of this group.</div>
             <md-table-container>
-                <table md-table>
-                    <thead md-head>
-                    <tr md-row>
-                        <th md-column>Name</th>
-                        <th md-column>Version</th>
-                        <th md-column>Visibility</th>
-                    </tr>
-                    </thead>
-                    <tbody md-body>
-                    <tr style="height: 30px;" ng-if="groupApis.length === 0">
-                        <td md-cell style="text-align: center;" colspan="3">None.</td>
-                    </tr>
-                    <tr ng-repeat="api in groupApis" md-row >
-                        <td md-cell>{{api.name}}</td>
-                        <td md-cell>{{api.version}}</td>
-                        <td md-cell>
-                            <ng-md-icon icon="{{api.visibility==='public' ? 'public' : 'lock'}}" size="20" style="fill: #cdcdcd;">
-                                <md-tooltip>{{api.visibility}}</md-tooltip>
-                            </ng-md-icon>
-                        </td>
-                    </tr>
-                    </tbody>
-                </table>
+              <table md-table>
+                <thead md-head>
+                <tr md-row>
+                  <th md-column>Name</th>
+                  <th md-column>Version</th>
+                  <th md-column>Visibility</th>
+                </tr>
+                </thead>
+                <tbody md-body>
+                <tr style="height: 30px" ng-if="groupApis.length === 0">
+                  <td md-cell style="text-align: center" colspan="3">None.</td>
+                </tr>
+                <tr ng-repeat="api in groupApis" md-row>
+                  <td md-cell>{{api.name}}</td>
+                  <td md-cell>{{api.version}}</td>
+                  <td md-cell>
+                    <ng-md-icon icon="{{api.visibility==='public' ? 'public' : 'lock'}}" size="20" style="fill: #cdcdcd">
+                      <md-tooltip>{{api.visibility}}</md-tooltip>
+                    </ng-md-icon>
+                  </td>
+                </tr>
+                </tbody>
+              </table>
             </md-table-container>
-        </md-tab-body>
-    </md-tab>
-    <md-tab md-on-select="currentTab='applications'; $ctrl.loadGroupApplications();">
-        <md-tab-label>Applications</md-tab-label>
-        <md-tab-body>
-            <div style="margin: 16px 0 8px;">Here is the list of all applications of this group.</div>
+          </md-tab-body>
+        </md-tab>
+        <md-tab md-on-select="currentTab='applications'; $ctrl.loadGroupApplications();">
+          <md-tab-label>Applications</md-tab-label>
+          <md-tab-body>
+            <div style="margin: 16px 0 8px">Here is the list of all applications of this group.</div>
             <md-table-container>
-                <table md-table>
-                    <thead md-head>
-                    <tr md-row>
-                        <th md-column>Name</th>
-                        <th md-column>Type</th>
-                    </tr>
-                    </thead>
-                    <tbody md-body>
-                    <tr style="height: 30px;" ng-if="groupApplications.length === 0">
-                        <td md-cell style="text-align: center;" colspan="2">None.</td>
-                    </tr>
-                    <tr ng-repeat="application in groupApplications" md-row >
-                        <td md-cell>{{application.name}}</td>
-                        <td md-cell>{{application.type}}</td>
-                    </tr>
-                    </tbody>
-                </table>
+              <table md-table>
+                <thead md-head>
+                <tr md-row>
+                  <th md-column>Name</th>
+                  <th md-column>Type</th>
+                </tr>
+                </thead>
+                <tbody md-body>
+                <tr style="height: 30px" ng-if="groupApplications.length === 0">
+                  <td md-cell style="text-align: center" colspan="2">None.</td>
+                </tr>
+                <tr ng-repeat="application in groupApplications" md-row>
+                  <td md-cell>{{application.name}}</td>
+                  <td md-cell>{{application.type}}</td>
+                </tr>
+                </tbody>
+              </table>
             </md-table-container>
-        </md-tab-body>
-    </md-tab>
-</md-tabs>
-        </div>
+          </md-tab-body>
+        </md-tab>
+      </md-tabs>
     </div>
+  </div>
 </div>
 
-<md-fab-speed-dial ng-if="$ctrl.canAddMembers() || ($ctrl.group.system_invitation && $ctrl.group.email_invitation)"
-                   md-direction="left" md-open="false" class="md-scale md-fab-bottom-right md-fab-scrollable"
-                   ng-class="{'gv-help-displayed': $ctrl.$rootScope.helpDisplayed}">
+<md-fab-speed-dial
+  ng-if="$ctrl.canAddMembers() || ($ctrl.group.system_invitation && $ctrl.group.email_invitation)"
+  md-direction="left"
+  md-open="false"
+  class="md-scale md-fab-bottom-right md-fab-scrollable"
+  ng-class="{'gv-help-displayed': $ctrl.$rootScope.helpDisplayed}"
+>
   <md-fab-trigger>
     <md-button aria-label="menu" class="md-fab md-success">
       <md-tooltip md-direction="top" md-visible="false">Add member</md-tooltip>
@@ -328,22 +398,34 @@
   </md-fab-trigger>
 
   <md-fab-actions>
-    <md-button ng-if="$ctrl.isSuperAdmin() || $ctrl.group.system_invitation"
-               class="md-fab md-success md-mini" ng-click="$ctrl.showAddMemberModal()" aria-label="Add member">
+    <md-button
+      ng-if="$ctrl.isSuperAdmin() || $ctrl.group.system_invitation"
+      class="md-fab md-success md-mini"
+      ng-click="$ctrl.showAddMemberModal()"
+      aria-label="Add member"
+    >
       <md-tooltip md-direction="top">Add member</md-tooltip>
       <ng-md-icon icon="people"></ng-md-icon>
     </md-button>
-    <md-button ng-if="$ctrl.isSuperAdmin() || $ctrl.group.email_invitation"
-               class="md-fab md-success md-mini" ng-click="$ctrl.showInviteMemberModal()" aria-label="Invite member">
+    <md-button
+      ng-if="$ctrl.isSuperAdmin() || $ctrl.group.email_invitation"
+      class="md-fab md-success md-mini"
+      ng-click="$ctrl.showInviteMemberModal()"
+      aria-label="Invite member"
+    >
       <md-tooltip md-direction="topmd-fab-bottom-right">Invite member</md-tooltip>
       <ng-md-icon icon="email"></ng-md-icon>
     </md-button>
   </md-fab-actions>
 </md-fab-speed-dial>
 
-<md-button ng-if="!$ctrl.isSuperAdmin() && !($ctrl.group.system_invitation && $ctrl.group.email_invitation) && ($ctrl.group.system_invitation || $ctrl.group.email_invitation)"
-           ng-click="$ctrl.group.system_invitation?$ctrl.showAddMemberModal(): $ctrl.showInviteMemberModal()" aria-label="Add member" class="md-fab md-fab-bottom-right md-fab-scrollable"
-           ng-class="{'gv-help-displayed': $ctrl.$rootScope.helpDisplayed}">
+<md-button
+  ng-if="!$ctrl.isSuperAdmin() && !($ctrl.group.system_invitation && $ctrl.group.email_invitation) && ($ctrl.group.system_invitation || $ctrl.group.email_invitation)"
+  ng-click="$ctrl.group.system_invitation?$ctrl.showAddMemberModal(): $ctrl.showInviteMemberModal()"
+  aria-label="Add member"
+  class="md-fab md-fab-bottom-right md-fab-scrollable"
+  ng-class="{'gv-help-displayed': $ctrl.$rootScope.helpDisplayed}"
+>
   <md-tooltip md-direction="top" md-visible="false">Add member</md-tooltip>
   <ng-md-icon icon="add"></ng-md-icon>
 </md-button>

--- a/src/management/configuration/groups/group/inviteMember.dialog.html
+++ b/src/management/configuration/groups/group/inviteMember.dialog.html
@@ -26,7 +26,7 @@
                    class="md-no-underline" ng-disabled="!$ctrl.canChangeDefaultApiRole()">
           <md-option ng-repeat="role in $ctrl.apiRoles"
                      ng-value="role.name"
-                     ng-disabled="role.system">
+                     ng-disabled="$ctrl.isApiRoleDisabled(role)">
             {{role.name}}
           </md-option>
         </md-select>

--- a/src/management/configuration/groups/groups.html
+++ b/src/management/configuration/groups/groups.html
@@ -39,6 +39,7 @@
                 <a ng-click="$ctrl.selectGroupUrl(group)">
                     {{group.name}}
                 </a>
+                <span ng-if="group.primary_owner" flex class="badge" style="background-color: #039be5">Primary Owner</span>
             </td>
             <td md-cell style="text-align: center;">
               <ng-md-icon ng-if="$ctrl.hasEvent(group, 'API_CREATE')" icon="done"></ng-md-icon>
@@ -47,7 +48,7 @@
               <ng-md-icon ng-if="$ctrl.hasEvent(group, 'APPLICATION_CREATE')" icon="done"></ng-md-icon>
             </td>
             <td md-cell ng-click="$event.stopPropagation()" layout="row" style="padding: 10px 0;">
-              <span ng-if="group.manageable">
+              <span ng-if="group.manageable && !group.primary_owner">
                 <md-tooltip md-direction="top">Delete</md-tooltip>
                 <ng-md-icon icon="delete" ng-click="$ctrl.removeGroup($event, group.id, group.name)" aria-label="delete-group"></ng-md-icon>
               </span>

--- a/src/management/configuration/portal/portal.html
+++ b/src/management/configuration/portal/portal.html
@@ -92,6 +92,16 @@
         </md-chips>
         <md-tooltip ng-if="$ctrl.isReadonlySetting('api.labelsDictionary')">Configuration provided by the system</md-tooltip>
       </md-input-container>
+
+      <h3>API Primary Owner mode</h3>
+      <md-input-container class="md-block">
+        <md-radio-group ng-model="$ctrl.settings.api.primaryOwnerMode">
+          <md-radio-button ng-value="'HYBRID'" aria-label="Hybrid">HYBRID: an API primary owner can be either a user or a group (Default)</md-radio-button>
+          <md-radio-button ng-value="'USER'" aria-label="User">USER: an API primary owner can only be a user</md-radio-button>
+          <md-radio-button ng-value="'GROUP'" aria-label="Group">GROUP: an API primary owner can only be a group</md-radio-button>
+        </md-radio-group>
+        <md-tooltip ng-if="$ctrl.isReadonlySetting('api.primaryOwnerMode')">Configuration provided by the system</md-tooltip>
+      </md-input-container>
     </div>
   </div>
 

--- a/src/management/management.module.ts
+++ b/src/management/management.module.ts
@@ -34,7 +34,8 @@ import GvModelDirective from '../libraries/gv-model.directive';
 import ApiService from '../services/api.service';
 import CorsService from '../services/cors.service';
 import ApisController from '../management/api/apis.controller';
-import ApisStatusDashboardController from '../management/dashboard/apis-status-dashboard/apis-status-dashboard.controller';
+import ApisStatusDashboardController
+  from '../management/dashboard/apis-status-dashboard/apis-status-dashboard.controller';
 import ApiPortalController from '../management/api/portal/general/apiPortal.controller';
 import ApiAdminController from '../management/api/apiAdmin.controller';
 import ApiAnalyticsController from '../management/api/analytics/overview/analytics.controller';
@@ -101,6 +102,8 @@ import ApiEditPlanWizardSecurityComponent from '../management/api/portal/plans/p
 import ApiEditPlanWizardRestrictionsComponent
   from '../management/api/portal/plans/plan/plan-wizard-restrictions.component';
 import ApiEditPlanWizardPoliciesComponent from '../management/api/portal/plans/plan/plan-wizard-policies.component';
+// API PrimaryOwner Mode
+import ApiPrimaryOwnerModeService from '../services/apiPrimaryOwnerMode.service';
 // API Subscription
 import ApiSubscriptionsComponent from '../management/api/portal/subscriptions/subscriptions.component';
 import ApiSubscriptionComponent from '../management/api/portal/subscriptions/subscription.component';
@@ -787,6 +790,7 @@ const graviteeManagementModule = angular.module('gravitee-management', [uiRouter
   graviteeManagementModule.service('ApplicationService', ApplicationService);
   graviteeManagementModule.service('ApplicationTypesService', ApplicationTypesService);
   graviteeManagementModule.service('ApiService', ApiService);
+  graviteeManagementModule.service('ApiPrimaryOwnerModeService', ApiPrimaryOwnerModeService);
   graviteeManagementModule.service('CorsService', CorsService);
   graviteeManagementModule.service('DocumentationService', DocumentationService);
   graviteeManagementModule.service('InstancesService', InstancesService);

--- a/src/services/apiPrimaryOwnerMode.service.ts
+++ b/src/services/apiPrimaryOwnerMode.service.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export enum ApiPrimaryOwnerMode {
+  HYBRID = 'HYBRID',
+  USER = 'USER',
+  GROUP = 'GROUP',
+}
+
+class ApiPrimaryOwnerModeService {
+
+  constructor(private Constants) {
+    'ngInject';
+  }
+
+  isGroupOnly = () => {
+    return this.Constants.env.settings.api.primaryOwnerMode.toUpperCase() === ApiPrimaryOwnerMode.GROUP;
+  }
+
+  isUserOnly = () => {
+    return this.Constants.env.settings.api.primaryOwnerMode.toUpperCase() === ApiPrimaryOwnerMode.USER;
+  }
+
+  isHybrid = () => {
+    return this.Constants.env.settings.api.primaryOwnerMode.toUpperCase() === ApiPrimaryOwnerMode.HYBRID;
+  }
+}
+
+export default ApiPrimaryOwnerModeService;
+


### PR DESCRIPTION
* Manage API PO in a group
  * authorize at most 1 API PRIMARY OWNER member in a group
  * use the new 'apiPrimaryOwner' field of the GroupEntity object. It is computed when necessary, on every operation on group members.
* don't link an API to a PO group
  * filters groups list when creating an API
  * disables the PO role when the group is already linked to an API
* make user-autocomplete deactivable
* allow a group to be the PO of an API
  * allow ownership transfer to and from
  * allow PO group selection in API creation
* add a "group only" mode
  * get the config from the management API
  * add a service to manage this mode
  * when a group is po of an API, it is also attached to the API. When this group is no more a PO, it is removed from API groups.

Closes gravitee-io/issues#5133
Closes gravitee-io/issues#5135
Closes gravitee-io/issues#5137
Closes gravitee-io/issues#5162
