### PR TITLE
fix(management): permissions must be must multi-scoped checked #5278

### DIFF
--- a/src/entities/user.ts
+++ b/src/entities/user.ts
@@ -55,10 +55,8 @@ export class User {
     if (!permissions || !this.userPermissions) {
       return false;
     }
-    return _.difference(permissions, this.userPermissions).length === 0 ||
-      _.difference(permissions, this.userEnvironmentPermissions).length === 0 ||
-      _.difference(permissions, this.userApiPermissions).length === 0 ||
-      _.difference(permissions, this.userApplicationPermissions).length === 0;
+
+    return _.difference(permissions, [...this.userPermissions || [], ...this.userEnvironmentPermissions || [], ...this.userApiPermissions || [], ...this.userApplicationPermissions || []]).length === 0;
   }
 
   isAdmin(): boolean {


### PR DESCRIPTION
I do not find any testing files.
The bug comes from the scope of permissions checked.
Actually, the function returns true only if all asked permissions are included in userPermissions OR userEnvironmentPermissions ORuserApiPermissions.
Each permission should be included in at least one group.