### PR TITLE
fix(management): hide Logs menu if no permission

### DIFF
--- a/src/management/api/analytics/apis.analytics.route.html
+++ b/src/management/api/analytics/apis.analytics.route.html
@@ -32,7 +32,13 @@
         <li class="iterable-item" ui-sref-active="aui-nav-selected" ui-sref="management.apis.detail.analytics.overview">
           <a class="execute">Overview</a>
         </li>
-        <li class="iterable-item" ui-sref-active="aui-nav-selected" ui-sref="management.apis.detail.analytics.logs">
+        <li
+          class="iterable-item"
+          permission
+          permission-only="['api-log-r']"
+          ui-sref-active="aui-nav-selected"
+          ui-sref="management.apis.detail.analytics.logs"
+        >
           <a class="execute">Logs</a>
         </li>
         <li


### PR DESCRIPTION
Fixes gravitee-io/issues#5412