### PR TITLE
fix(management): OIDC logout uses the right URL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gravitee-management-webui",
-  "version": "3.8.2",
+  "version": "3.8.3-SNAPSHOT",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/index.route.ts
+++ b/src/index.route.ts
@@ -162,7 +162,19 @@ function routerConfig($stateProvider: StateProvider, $urlServiceProvider: UrlSer
           $window.localStorage.removeItem('user-logout-url');
           reinitToDefaultOrganization($window, Constants);
           if (userLogoutEndpoint != null) {
-            $window.location.href = userLogoutEndpoint + encodeURIComponent(window.location.origin);
+            const redirectUri = window.location.origin + (window.location.pathname === '/' ? '' : window.location.pathname);
+            if (userLogoutEndpoint.endsWith('target_url=')) {
+              // If we use a Gravitee AM IDP, the logoutEndpoint will end with `target_url=` (See AMIdentityProviderEntity.java)
+              // We must fill this query param so older versions of AM still work.
+              $window.location.href =
+                userLogoutEndpoint + encodeURIComponent(redirectUri) + '&post_logout_redirect_uri=' + encodeURIComponent(redirectUri);
+            } else if (userLogoutEndpoint.endsWith('post_logout_redirect_uri=')) {
+              // Otherwise we use an OIDC IDP, and the logout endpoint may already contain the `post_logout_redirect_uri`
+              $window.location.href = userLogoutEndpoint + encodeURIComponent(redirectUri);
+            } else {
+              const separator = userLogoutEndpoint.indexOf('?') > -1 ? '&' : '?';
+              $window.location.href = userLogoutEndpoint + separator + 'post_logout_redirect_uri=' + encodeURIComponent(redirectUri);
+            }
           }
         });
       },


### PR DESCRIPTION
* Instead of using only `window.location.href`, use also `window.location.pathname` to determine the correct redirect URL
* Also add `post_logout_redirect_uri` path parameter to be able to handle the logout process correctly

Fixes gravitee-io/issues#5621