### PR TITLE
feat(management): handle asciidoc pages in documentation

### DIFF
--- a/build.json
+++ b/build.json
@@ -1,3 +1,3 @@
 {
-  "version": "3.9.0"
+  "version": "3.10.0-SNAPSHOT"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1368,9 +1368,9 @@
       "integrity": "sha512-KWk80UPIzPmUg+P0rKh6TqspRw0G6eux1PuJr+zz47ftMaZ9QDwbGzHZbtzWkl5hgayM/qrKRutllRC7D/vVXQ=="
     },
     "@gravitee/ui-components": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@gravitee/ui-components/-/ui-components-3.5.0.tgz",
-      "integrity": "sha512-uUG6EbB3O/C3/BnaQlbeGdfrjNRmRY5OvxKOoYqPFjGypM57AvUu13LY2QJmVifYgLzTQTZlKi8DCXHV3KJCiA==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@gravitee/ui-components/-/ui-components-3.8.0.tgz",
+      "integrity": "sha512-2GD4Bgz3ad0ncP7keh9ef4V/yWvirwPOgvb4Du5bTmdR3MijUOj02l2hkku0lA0dwli0Z83Dwm1o6gQ3lhDjrQ==",
       "requires": {
         "@formatjs/intl-relativetimeformat": "^4.5.9",
         "clipboard-copy": "^3.1.0",
@@ -4327,6 +4327,11 @@
       "version": "5.59.4",
       "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.59.4.tgz",
       "integrity": "sha512-achw5JBgx8QPcACDDn+EUUXmCYzx/zxEtOGXyjvLEvYY8GleUrnfm5D+Zb+UjShHggXKDT9AXrbkBZX6a0YSQg=="
+    },
+    "codemirror-asciidoc": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/codemirror-asciidoc/-/codemirror-asciidoc-1.0.4.tgz",
+      "integrity": "sha1-dDn8w48w8UCKsUTRVr85jtNbLMA="
     },
     "collect-v8-coverage": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Gravitee.io APIM - Portal",
   "dependencies": {
     "@fontsource/libre-franklin": "^4.4.5",
-    "@gravitee/ui-components": "^3.5.0",
+    "@gravitee/ui-components": "^3.8.0",
     "@highcharts/map-collection": "^1.1.3",
     "@toast-ui/editor": "^2.5.2",
     "@toast-ui/editor-plugin-code-syntax-highlight": "^1.0.0",
@@ -37,6 +37,7 @@
     "asciidoctor": "^2.2.4",
     "asciidoctor-highlight.js": "^0.3.0",
     "bootstrap": "3.4.1",
+    "codemirror-asciidoc": "^1.0.4",
     "diff": "^3.5.0",
     "dragular": "^4.6.0",
     "highcharts": "^9.1.1",

--- a/src/assets/logo_asciidoc.svg
+++ b/src/assets/logo_asciidoc.svg
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="105.83333mm"
+   height="105.83333mm"
+   viewBox="0 0 105.83333 105.83333"
+   version="1.1"
+   id="svg3751"
+   inkscape:export-filename="/tmp/asciidoctor-logo-fill-color.png"
+   inkscape:export-xdpi="240"
+   inkscape:export-ydpi="240"
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
+  <title
+     id="title4527">Asciidoctor</title>
+  <defs
+     id="defs3745" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.6245048"
+     inkscape:cx="-46.777153"
+     inkscape:cy="24.966208"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="3200"
+     inkscape:window-height="1658"
+     inkscape:window-x="0"
+     inkscape:window-y="68"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata3748">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Asciidoctor</dc:title>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>Asciidoctor</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:description>Asciidoctor project logo.</dc:description>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>AsciiDoc</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:relation>https://asciidoctor.org</dc:relation>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-0.083335,-191.08337)">
+    <path
+       inkscape:connector-curvature="0"
+       id="path907"
+       d="m 26.240746,191.08337 c -14.436702,0 -26.157411,11.7201 -26.157411,26.15666 v 53.51951 c 0,14.43654 11.720957,26.15715 26.157411,26.15715 H 79.76025 c 14.436679,0 26.15641,-11.72061 26.15641,-26.15715 v -53.51951 c 0,-14.43656 -11.719488,-26.15666 -26.15641,-26.15666 z"
+       style="clip-rule:evenodd;fill:#e40046;fill-opacity:1;fill-rule:evenodd;stroke-width:0.24752024;stroke-linejoin:round;stroke-miterlimit:1.41420996" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4.46009064px;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 55.70942,210.48548 a 2.2302684,2.2302684 0 0 0 -2.015517,1.37263 l -13.327365,32.05565 a 2.2302684,2.2302684 0 1 0 4.117839,1.71171 l 11.25217,-27.06706 23.600261,57.54395 a 2.2302684,2.2302684 0 1 0 4.125976,-1.69271 L 57.814455,211.86894 a 2.2302684,2.2302684 0 0 0 -2.105035,-1.38346 z"
+       id="path909"
+       inkscape:connector-curvature="0" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path911"
+       d="m 36.817184,255.95416 a 2.2302685,2.2302685 0 0 0 -2.024151,1.40272 l -7.083967,17.04249 a 2.2302685,2.2302685 0 1 0 4.118502,1.71234 l 7.083967,-17.0425 a 2.2302685,2.2302685 0 0 0 -2.094351,-3.11505 z"
+       style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4.46009111px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:1.5;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4.46009111px;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 21.548721,254.55016 a 2.2302685,2.2302685 0 1 0 0,4.45963 h 25.754124 a 2.2302685,2.2302685 0 1 0 0,-4.45964 z"
+       id="path915"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4.46009111px;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 26.263348,243.9626 a 2.2302685,2.2302685 0 1 0 0,4.45962 h 25.751411 a 2.2302685,2.2302685 0 1 0 0,-4.45962 z"
+       id="path919"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/src/components/documentation/documentation-management.component.ts
+++ b/src/components/documentation/documentation-management.component.ts
@@ -93,6 +93,7 @@ class DocumentationManagementComponentController implements IController {
 
   canCreateShortCut(pageId: string, pageType: string) {
     return (
+      pageType === 'ASCIIDOC' ||
       pageType === 'SWAGGER' ||
       pageType === 'MARKDOWN' ||
       (pageType === 'FOLDER' &&

--- a/src/components/documentation/documentation.module.ts
+++ b/src/components/documentation/documentation.module.ts
@@ -27,6 +27,7 @@ import { EditPageFetchersComponent } from './edit-tabs/edit-page-fetchers.compon
 import { EditPageTranslationsComponent } from './edit-tabs/edit-page-translations.components';
 import { ImportPagesComponent } from './import-pages.component';
 import { NewPageComponent } from './new-page.component';
+import { PageAsciiDocComponent } from './page/page-asciidoc.component';
 import { PageEditorMarkdownComponent } from './page/page-editormarkdown.component';
 import { PageMarkdownComponent } from './page/page-markdown.component';
 import { PageSwaggerComponent } from './page/page-swagger.component';
@@ -50,6 +51,7 @@ graviteeDocumentationModule.component('gvEditPageFetchers', EditPageFetchersComp
 graviteeDocumentationModule.component('gvEditPageTranslations', EditPageTranslationsComponent);
 graviteeDocumentationModule.component('importPages', ImportPagesComponent);
 graviteeDocumentationModule.component('newPage', NewPageComponent);
+graviteeDocumentationModule.component('gvPageAsciiDoc', PageAsciiDocComponent);
 graviteeDocumentationModule.component('gvPageEditorMarkdown', PageEditorMarkdownComponent);
 graviteeDocumentationModule.component('gvPageMarkdown', PageMarkdownComponent);
 graviteeDocumentationModule.component('gvPageSwagger', PageSwaggerComponent);

--- a/src/components/documentation/edit-page.component.ts
+++ b/src/components/documentation/edit-page.component.ts
@@ -176,6 +176,9 @@ class EditPageComponentController implements IController {
   isMarkdownTemplate(): boolean {
     return PageType.MARKDOWN_TEMPLATE === this.page.type;
   }
+  isAsciiDoc(): boolean {
+    return PageType.ASCIIDOC === this.page.type;
+  }
 
   initEditor() {
     this.$scope.editorReadonly = false;

--- a/src/components/documentation/edit-page.html
+++ b/src/components/documentation/edit-page.html
@@ -97,9 +97,11 @@
               ></gv-edit-page-content>
               <gv-edit-link-content
                 ng-if="$ctrl.isLink()"
-                categoryResources="$ctrl.categoryResources"
+                category-resources="$ctrl.categoryResources"
+                folders-by-id="$ctrl.foldersById"
                 page="$ctrl.page"
-                pageList="$ctrl.pageList"
+                page-list="$ctrl.pageList"
+                system-folders-by-id="$ctrl.systemFoldersById"
               ></gv-edit-link-content>
             </div>
           </md-tab-body>
@@ -144,13 +146,14 @@
         </md-tab>
 
         <!-- Attached resources -->
-        <md-tab md-on-select="$ctrl.selectTab(5)" ng-if="$ctrl.canUpdate && $ctrl.isMarkdown()">
+        <md-tab md-on-select="$ctrl.selectTab(5)" ng-if="$ctrl.canUpdate && ($ctrl.isMarkdown() || $ctrl.isAsciiDoc())">
           <md-tab-label>Attached resources</md-tab-label>
           <md-tab-body>
             <gv-edit-page-attached-resources
+              api-id="$ctrl.apiId"
               attached-resources="$ctrl.attachedResources"
-              goto-function="$ctrl.reset"
               page="$ctrl.page"
+              on-save="$ctrl.reset()"
             ></gv-edit-page-attached-resources>
           </md-tab-body>
         </md-tab>

--- a/src/components/documentation/edit-tabs/edit-link-content.components.ts
+++ b/src/components/documentation/edit-tabs/edit-link-content.components.ts
@@ -14,14 +14,33 @@
  * limitations under the License.
  */
 import { IController } from 'angular';
+import DocumentationService from '../../../services/documentation.service';
 
 class EditLinkContentComponentController implements IController {
   categoryResources: any[];
+  foldersById: any;
   page: any;
   pageList: any[];
+  systemFoldersById: any;
 
-  constructor() {
+  constructor(private readonly DocumentationService: DocumentationService) {
     'ngInject';
+  }
+
+  checkIfFolder() {
+    if (this.page.content) {
+      if (this.page.content === 'root') {
+        this.page.configuration.isFolder = true;
+        this.page.configuration.inherit = 'false';
+      } else {
+        const folder = this.DocumentationService.getFolder(this.systemFoldersById, this.foldersById, this.page.content);
+        if (folder) {
+          this.page.configuration.isFolder = true;
+        } else {
+          this.page.configuration.isFolder = false;
+        }
+      }
+    }
   }
 
   onChangeLinkType() {
@@ -61,8 +80,10 @@ class EditLinkContentComponentController implements IController {
 export const EditLinkContentComponent: ng.IComponentOptions = {
   bindings: {
     categoryResources: '<',
+    foldersById: '<',
     page: '<',
     pageList: '<',
+    systemFoldersById: '<',
   },
   template: require('./edit-link-content.html'),
   controller: EditLinkContentComponentController,

--- a/src/components/documentation/edit-tabs/edit-page-content.components.ts
+++ b/src/components/documentation/edit-tabs/edit-page-content.components.ts
@@ -15,6 +15,7 @@
  */
 import { IController, IScope } from 'angular';
 import { PageType } from '../../../services/documentation.service';
+import '@gravitee/ui-components/wc/gv-code';
 
 interface IPageScope extends IScope {
   editorReadonly: boolean;
@@ -27,12 +28,16 @@ class EditPageContentComponentController implements IController {
   pagesToLink: any[];
   pageType: string;
 
-  swaggerCodeMirrorOptions: any;
+  // for asciidoc & swagger
+  codeMirrorOptions: any;
 
   constructor(private $scope: IPageScope) {
     'ngInject';
   }
 
+  isAsciiDoc(): boolean {
+    return PageType.ASCIIDOC === this.pageType;
+  }
   isSwagger(): boolean {
     return PageType.SWAGGER === this.pageType;
   }
@@ -48,13 +53,17 @@ class EditPageContentComponentController implements IController {
       this.pageType = this.page.type;
     }
 
-    this.swaggerCodeMirrorOptions = {
-      viewportMargin: 50,
+    this.codeMirrorOptions = {
       lineWrapping: true,
       lineNumbers: true,
       readOnly: this.$scope.editorReadonly,
-      mode: { name: 'javascript', json: true },
     };
+    if (this.isSwagger()) {
+      this.codeMirrorOptions.mode = 'json';
+    }
+    if (this.isAsciiDoc()) {
+      this.codeMirrorOptions.mode = 'asciidoc';
+    }
   }
 }
 

--- a/src/components/documentation/edit-tabs/edit-page-content.html
+++ b/src/components/documentation/edit-tabs/edit-page-content.html
@@ -15,22 +15,29 @@
     limitations under the License.
 
 -->
-<!-- edit SWAGGER inline -->
-<div ng-if="$ctrl.isSwagger()" style="display: inline-block; width: 100%">
-  <div layout="row" ng-class="{'newPageEditor': $ctrl.newPage, 'editPageEditor': !$ctrl.newPage}" style="height: calc(100vh - 400px)">
-    <div ng-if="$ctrl.canUpdate" flex="50">
-      <textarea
-        ui-codemirror
-        ui-codemirror-opts="$ctrl.swaggerCodeMirrorOptions"
-        ng-model="$ctrl.page.content"
-        aria-label="page content"
-        ng-disabled="$ctrl.page.source"
-        md-autofocus
-      ></textarea>
-    </div>
-    <div ng-if="!$ctrl.newPage" style="height: 100%; overflow-y: scroll" flex="50">
-      <gv-page-swagger page="$ctrl.page" edit="$ctrl.canUpdate"></gv-page-swagger>
-    </div>
+<!-- edit AsciiDoc or SWAGGER inline -->
+<div ng-if="$ctrl.isSwagger() || $ctrl.isAsciiDoc()" style="display: inline-block; width: 100%">
+  <div layout="row" ng-class="{'newPageEditor': $ctrl.newPage, 'editPageEditor': !$ctrl.newPage}">
+    <gv-code
+      ng-if="$ctrl.canUpdate"
+      class="editPanel"
+      flex="50"
+      autofocus
+      ng-attr-value="{{$ctrl.page.content}}"
+      ng-attr-options="{{$ctrl.codeMirrorOptions}}"
+      ng-model="$ctrl.page.content"
+      gv-model
+    ></gv-code>
+    <gv-page-ascii-doc ng-if="$ctrl.isAsciiDoc()" class="editPanel" flex="50" page-content="$ctrl.page.content"></gv-page-ascii-doc>
+    <gv-page-swagger
+      ng-if="$ctrl.isSwagger()"
+      class="editPanel"
+      flex="50"
+      page="$ctrl.page"
+      page-content="$ctrl.page.content"
+      page-configuration="$ctrl.page.configuration"
+      edit="$ctrl.canUpdate"
+    ></gv-page-swagger>
   </div>
 </div>
 

--- a/src/components/documentation/edit-tabs/edit-page-translations.components.ts
+++ b/src/components/documentation/edit-tabs/edit-page-translations.components.ts
@@ -52,7 +52,12 @@ class EditPageTranslationsComponentController implements IController {
       parentId: this.page.id,
       configuration: {},
     };
-    if (this.page.type === PageType.MARKDOWN || this.page.type === PageType.SWAGGER || this.page.type === PageType.LINK) {
+    if (
+      this.page.type === PageType.MARKDOWN ||
+      this.page.type === PageType.SWAGGER ||
+      this.page.type === PageType.LINK ||
+      this.page.type === PageType.ASCIIDOC
+    ) {
       this.currentTranslation.configuration.inheritContent = 'true';
     }
   }

--- a/src/components/documentation/new-page.component.ts
+++ b/src/components/documentation/new-page.component.ts
@@ -96,6 +96,8 @@ class NewPageComponentController implements IController {
 
   getPageName(): string {
     switch (this.page.type) {
+      case PageType.ASCIIDOC:
+        return 'New AsciiDoc';
       case PageType.FOLDER:
         return 'New Folder';
       case PageType.LINK:

--- a/src/components/documentation/new-page.html
+++ b/src/components/documentation/new-page.html
@@ -36,7 +36,7 @@
     ></gv-new-link>
   </div>
 
-  <!-- SWAGGER, MARKDOWN or MARKDOWN_TEMPLATE-->
+  <!-- ASCIIDOC, SWAGGER, MARKDOWN or MARKDOWN_TEMPLATE-->
   <div class="gv-form" ng-if="!$ctrl.isFolder() && !$ctrl.isLink()">
     <h2></h2>
     <div class="gv-form-content" layout="column">

--- a/src/components/documentation/page/_page.scss
+++ b/src/components/documentation/page/_page.scss
@@ -188,6 +188,7 @@
 
 .CodeMirror {
   font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  height: 100%;
 }
 
 .newPageEditor {
@@ -198,8 +199,9 @@
   height: calc(100vh - 400px);
 }
 
-.CodeMirror {
+.editPanel {
   height: 100%;
+  overflow-y: scroll;
 }
 
 .tui-editor-contents *:not(table) {

--- a/src/components/documentation/page/page-asciidoc.component.ts
+++ b/src/components/documentation/page/page-asciidoc.component.ts
@@ -13,12 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const ErrorComponent: ng.IComponentOptions = {
-  template: require('./error.html'),
-  controller: 'ErrorController',
-  bindings: {
-    error: '<',
-  },
-};
+import '@gravitee/ui-components/wc/gv-documentation';
 
-export default ErrorComponent;
+class PageAsciiDocComponentController implements ng.IComponentController {
+  pageContent: any;
+}
+
+export const PageAsciiDocComponent: ng.IComponentOptions = {
+  template: require('./page-asciidoc.html'),
+  bindings: {
+    pageContent: '<',
+  },
+  controller: PageAsciiDocComponentController,
+};

--- a/src/components/documentation/page/page-asciidoc.html
+++ b/src/components/documentation/page/page-asciidoc.html
@@ -1,0 +1,23 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<gv-documentation ng-attr-text="{{$ctrl.pageContent}}" ng-attr-without-header="'true'">
+  <div slot="empty">
+    <gv-icon shape="text:align-center" style="--gv-icon--s: 96px"></gv-icon>
+    <div>No content to display</div>
+  </div>
+</gv-documentation>

--- a/src/libraries/gv-model.directive.ts
+++ b/src/libraries/gv-model.directive.ts
@@ -36,7 +36,7 @@ class GvModelDirective {
           element[0].value = ngModel.$viewValue;
         };
 
-        element.on('input', (e) => {
+        element.on(`${element[0].localName}:input`, (e) => {
           ngModel.$setViewValue(e.target.value);
         });
       },

--- a/src/management/api/portal/apis.portal.route.ts
+++ b/src/management/api/portal/apis.portal.route.ts
@@ -402,7 +402,10 @@ function apisPortalRouterConfig($stateProvider) {
             q.homepage = false;
             q.published = true;
             return DocumentationService.search(q, $stateParams.apiId).then((response) =>
-              response.data.filter((page) => page.type.toUpperCase() === 'MARKDOWN' || page.type.toUpperCase() === 'SWAGGER'),
+              response.data.filter(
+                (page) =>
+                  page.type.toUpperCase() === 'MARKDOWN' || page.type.toUpperCase() === 'SWAGGER' || page.type.toUpperCase() === 'ASCIIDOC',
+              ),
             );
           }
         },
@@ -501,13 +504,16 @@ function apisPortalRouterConfig($stateProvider) {
             return DocumentationService.search(q, $stateParams.apiId).then((response) =>
               response.data.filter(
                 (page) =>
-                  (page.type.toUpperCase() === 'MARKDOWN' || page.type.toUpperCase() === 'SWAGGER') && page.id !== $stateParams.pageId,
+                  (page.type.toUpperCase() === 'MARKDOWN' ||
+                    page.type.toUpperCase() === 'SWAGGER' ||
+                    page.type.toUpperCase() === 'ASCIIDOC') &&
+                  page.id !== $stateParams.pageId,
               ),
             );
           }
         },
         attachedResources: (DocumentationService: DocumentationService, $stateParams: StateParams) => {
-          if ($stateParams.type === 'MARKDOWN') {
+          if ($stateParams.type === 'MARKDOWN' || $stateParams.type === 'ASCIIDOC') {
             return DocumentationService.getMedia($stateParams.pageId, $stateParams.apiId).then((response) => response.data);
           }
         },

--- a/src/management/api/portal/general/dialog/apiExport.dialog.html
+++ b/src/management/api/portal/general/dialog/apiExport.dialog.html
@@ -23,7 +23,8 @@
         <div layout="column" layout-align="space-between center">
           <md-select ng-model="data.exportVersion" placeholder="Export as">
             <md-option value="default" selected>Current version ({{ graviteeVersion }})</md-option>
-            <md-option value="3.0">3.0.x version</md-option>
+            <md-option value="3.7">3.7.x to 3.9.x version</md-option>
+            <md-option value="3.0">3.0.x to 3.6.x version</md-option>
             <md-option value="1.25">1.25.x to 1.30.x version</md-option>
             <md-option value="1.20">1.20.x to 1.24.x version</md-option>
             <md-option value="1.15">1.15.x to 1.16.x version</md-option>

--- a/src/management/configuration/configuration.route.ts
+++ b/src/management/configuration/configuration.route.ts
@@ -288,7 +288,10 @@ function configurationRouterConfig($stateProvider) {
             q.homepage = false;
             q.published = true;
             return DocumentationService.search(q).then((response) =>
-              response.data.filter((page) => page.type.toUpperCase() === 'MARKDOWN' || page.type.toUpperCase() === 'SWAGGER'),
+              response.data.filter(
+                (page) =>
+                  page.type.toUpperCase() === 'MARKDOWN' || page.type.toUpperCase() === 'SWAGGER' || page.type.toUpperCase() === 'ASCIIDOC',
+              ),
             );
           }
         },
@@ -385,7 +388,10 @@ function configurationRouterConfig($stateProvider) {
             return DocumentationService.search(q).then((response) =>
               response.data.filter(
                 (page) =>
-                  (page.type.toUpperCase() === 'MARKDOWN' || page.type.toUpperCase() === 'SWAGGER') && page.id !== $stateParams.pageId,
+                  (page.type.toUpperCase() === 'MARKDOWN' ||
+                    page.type.toUpperCase() === 'SWAGGER' ||
+                    page.type.toUpperCase() === 'ASCIIDOC') &&
+                  page.id !== $stateParams.pageId,
               ),
             );
           }
@@ -412,7 +418,7 @@ function configurationRouterConfig($stateProvider) {
           }
         },
         attachedResources: (DocumentationService: DocumentationService, $stateParams: StateParams) => {
-          if ($stateParams.type === 'MARKDOWN') {
+          if ($stateParams.type === 'MARKDOWN' || $stateParams.type === 'ASCIIDOC') {
             return DocumentationService.getMedia($stateParams.pageId, null).then((response) => response.data);
           }
         },

--- a/src/management/management.module.ts
+++ b/src/management/management.module.ts
@@ -563,7 +563,7 @@ require('angular-moment-picker');
 (<any>window).tinycolor = tinycolor;
 require('md-color-picker');
 
-const graviteeManagementModule = angular.module('gravitee-management', [
+angular.module('gravitee-management', [
   uiRouter,
   permission,
   uiPermission,
@@ -596,6 +596,8 @@ const graviteeManagementModule = angular.module('gravitee-management', [
   'mdColorPicker',
   'gravitee-component-documentation',
 ]);
+
+const graviteeManagementModule = angular.module('gravitee-management');
 
 graviteeManagementModule.config([
   'cfpLoadingBarProvider',
@@ -841,7 +843,7 @@ graviteeManagementModule.component('gvWidgetDataPieConfiguration', WidgetChartPi
 graviteeManagementModule.component('gvWidgetDataStatsConfiguration', WidgetDataStatsConfigurationComponent);
 graviteeManagementModule.component('gvError', ErrorComponent);
 graviteeManagementModule.component('gvPolicyStudioWrapper', PolicyStudioWrapperComponent);
-graviteeManagementModule.controller('errorCtrl', ErrorController);
+graviteeManagementModule.controller('ErrorController', ErrorController);
 
 graviteeManagementModule.component('categories', CategoriesComponent);
 graviteeManagementModule.component('category', CategoryComponent);

--- a/src/services/documentation.service.ts
+++ b/src/services/documentation.service.ts
@@ -54,6 +54,7 @@ export enum SystemFolderName {
 }
 
 export enum PageType {
+  ASCIIDOC = 'ASCIIDOC',
   FOLDER = 'FOLDER',
   LINK = 'LINK',
   SWAGGER = 'SWAGGER',
@@ -80,6 +81,7 @@ class DocumentationService {
     const pageList = pagesToFilter
       ?.filter(
         (p) =>
+          p.type === 'ASCIIDOC' ||
           p.type === 'MARKDOWN' ||
           p.type === 'SWAGGER' ||
           (p.type === 'FOLDER' && folderSituation !== FolderSituation.FOLDER_IN_SYSTEM_FOLDER),
@@ -112,13 +114,13 @@ class DocumentationService {
   supportedTypes(folderSituation: FolderSituation): PageType[] {
     switch (folderSituation) {
       case FolderSituation.ROOT:
-        return [PageType.SWAGGER, PageType.MARKDOWN, PageType.MARKDOWN_TEMPLATE, PageType.FOLDER];
+        return [PageType.ASCIIDOC, PageType.SWAGGER, PageType.MARKDOWN, PageType.MARKDOWN_TEMPLATE, PageType.FOLDER];
       case FolderSituation.SYSTEM_FOLDER:
         return [PageType.LINK];
       case FolderSituation.SYSTEM_FOLDER_WITH_FOLDERS:
         return [PageType.FOLDER, PageType.LINK];
       case FolderSituation.FOLDER_IN_FOLDER:
-        return [PageType.SWAGGER, PageType.MARKDOWN, PageType.MARKDOWN_TEMPLATE, PageType.FOLDER];
+        return [PageType.ASCIIDOC, PageType.SWAGGER, PageType.MARKDOWN, PageType.MARKDOWN_TEMPLATE, PageType.FOLDER];
       case FolderSituation.FOLDER_IN_SYSTEM_FOLDER:
         return [PageType.LINK];
     }


### PR DESCRIPTION
* use gv-documentation to render asciidoc
* use gv-code to edit swagger & asciidoc
* lint fixes
* fixes link edition (due to pages refactoring)

Related to gravitee-io/issues#4717