### PR TITLE
Display API roles in Access Control tab of an API doc page

### DIFF
--- a/src/components/documentation/edit-page.html
+++ b/src/components/documentation/edit-page.html
@@ -141,7 +141,7 @@
         <md-tab md-on-select="$ctrl.selectTab(4)" ng-if="$ctrl.canUpdate">
           <md-tab-label>Access Control</md-tab-label>
           <md-tab-body>
-            <gv-edit-page-acls page="$ctrl.page" groups="$ctrl.groups" roles="$ctrl.roles"></gv-edit-page-acls>
+            <gv-edit-page-acls page="$ctrl.page" groups="$ctrl.groups" roles="$ctrl.roles" is-api-page="!!$ctrl.apiId"></gv-edit-page-acls>
           </md-tab-body>
         </md-tab>
 

--- a/src/components/documentation/edit-tabs/edit-page-acls.components.ts
+++ b/src/components/documentation/edit-tabs/edit-page-acls.components.ts
@@ -25,13 +25,15 @@ class EditPageAclsComponentController implements IController {
   page: any;
   groups: any[];
   roles: any[];
+  isApiPage: boolean;
 
   constructor(private readonly RoleService: RoleService, private $scope: IPageScope) {
     'ngInject';
   }
 
   $onInit() {
-    this.RoleService.list('ENVIRONMENT').then((roles) => {
+    const scope = this.isApiPage ? 'API' : 'ENVIRONMENT';
+    this.RoleService.list(scope).then((roles) => {
       this.roles = roles;
     });
 
@@ -65,6 +67,7 @@ export const EditPageAclsComponent: ng.IComponentOptions = {
     page: '<',
     groups: '<',
     roles: '<',
+    isApiPage: '<',
   },
   template: require('./edit-page-acls.html'),
   controller: EditPageAclsComponentController,


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/5789

**Description**

Display API roles in `Access Control` tab of an API doc page instead of Environment roles.

**Screenshot**

API Documentation
![image](https://user-images.githubusercontent.com/4112568/126985422-1a4ad61b-d3d4-4be4-ad5a-d92b8a517a4a.png)

Global documentation
![image](https://user-images.githubusercontent.com/4112568/126985502-d35f6d05-ec60-472e-ac15-ce4920c3cf03.png)
