### PR TITLE
#5937 Permit user to import AsciiDocs file (.adoc) on step 4 of API creation flow.

### DIFF
--- a/docs/management-apis-create-steps.md
+++ b/docs/management-apis-create-steps.md
@@ -21,4 +21,4 @@ Auto-validation mode tells you if a manual action is required to validate a subs
 . Documentation **optional**
 
 Import documentation to make them available to the application teams.
-Support three types of document : Swagger, Markdown and Raml.
+Support three types of document : Swagger/OpenApi, Markdown and AsciiDoc.

--- a/docs/management-configuration-apiquality.md
+++ b/docs/management-configuration-apiquality.md
@@ -2,8 +2,7 @@
 
 Add a quality rate on apis according to criteria:
 
-- markdown documentation exists and is published
-- swagger documentation exists and is published
+- documentation exists and is published
 - a health-check is set
 - the description contains has a minimum length
 - the default logo is not used

--- a/docs/management-configuration-portal-pages.md
+++ b/docs/management-configuration-portal-pages.md
@@ -1,9 +1,10 @@
 # Portal pages
 
-At this date, two types of document are supported :
+At this date, three types of document are supported :
 
-* Swagger
+* Swagger/OpenApi
 * Markdown (MD)
+* AsciiDoc
 
 By default, portal pages are in staging mode and will be visible to administrator or users with management portal roles.
 To make documentation visible for all users, you can switch on the *published* button.

--- a/src/management/api/creation/steps/api-creation.controller.ts
+++ b/src/management/api/creation/steps/api-creation.controller.ts
@@ -459,11 +459,14 @@ class ApiCreationController {
           case 'JSON':
             file.type = 'SWAGGER';
             break;
+          case 'ADOC':
+            file.type = 'ASCIIDOC';
+            break;
         }
         if (file.type) {
           this.selectFile(file);
         } else {
-          this.NotificationService.showError('Only Markdown and OpenAPI file are supported');
+          this.NotificationService.showError('Only Markdown, OpenAPI, and AsciiDoc files are supported');
         }
       }
     });


### PR DESCRIPTION
Permit user to import AsciiDocs file (.adoc) on step 4 of API creation flow.
Adapt documentations too.
(see https://github.com/gravitee-io/issues/issues/5937).