### PR TITLE
fix: current user groups is a string list

### DIFF
--- a/src/management/api/creation/steps/api-creation.controller.ts
+++ b/src/management/api/creation/steps/api-creation.controller.ts
@@ -126,7 +126,7 @@ class ApiCreationController {
     this.attachableGroups = this.groups.filter((group) => group.apiPrimaryOwner == null);
     const currentUserGroups = this.UserService.getCurrentUserGroups();
     this.poGroups = this.groups.filter(
-      (group) => group.apiPrimaryOwner != null && currentUserGroups.some((userGroup) => userGroup.id === group.id),
+      (group) => group.apiPrimaryOwner != null && currentUserGroups.some((userGroup) => userGroup === group.name),
     );
   };
 


### PR DESCRIPTION
When the API Primary Owner mode is set to "GROUP", the API creation wizard requires a PO Group in the first step.
The list of available PO groups is filled with current user groups which are filters.

Currently, this filter assumes that a "user group" is an object. But it is a simple string list with group name only.

As a consequence, the PO groups list is always empty.

This PR fixes the filter.

![image](https://user-images.githubusercontent.com/13161768/127820851-007c0bdb-4671-4e1c-84e7-fed1bc47d747.png)
