### PR TITLE
Add SonarCloud analysis

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,7 @@ orbs:
   gravitee: gravitee-io/gravitee@1.0
   secrethub: secrethub/cli@1.1
   gh: circleci/github-cli@1.0
+  sonarcloud: sonarsource/sonarcloud@1.0
 
 executors:
   node-lts:
@@ -88,6 +89,22 @@ jobs:
       - run:
           name: Run unit tests
           command: npm run test:ci
+      - persist_to_workspace:
+          root: .
+          paths:
+            - coverage
+      - store_test_results:
+          path: coverage
+
+  sonarcloud-analysis:
+    executor:
+      name: node-lts
+      class: small
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - sonarcloud/scan
 
   build:
     executor:
@@ -149,6 +166,7 @@ jobs:
 
             _Notes_: The deployed app is linked to the management API of the Element Zero team's environment."
 
+
 workflows:
   pull_requests:
     when:
@@ -164,6 +182,14 @@ workflows:
       - lint-test:
           requires:
             - install
+      - sonarcloud-analysis:
+          context: cicd-orchestrator
+          pre-steps:
+            - secrethub/env-export:
+                secret-path: graviteeio/cicd/graviteebot/infra/sonarcloud.io.token
+                var-name: SONAR_TOKEN
+          requires:
+            - lint-test
       - build:
           requires:
             - install

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,13 @@
+sonar.projectKey=gravitee-io_gravitee-management-webui
+sonar.organization=gravitee-io
+
+# Path to sources
+sonar.sources=src
+
+# Source encoding
+sonar.sourceEncoding=UTF-8
+
+# Coverage
+sonar.test=src
+sonar.test.inclusions=**/*.spec.ts
+sonar.javascript.lcov.reportPaths=coverage/lcov.info


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6053

**Description**

  - Create a `sonar-project.properties` file at the root of the repo
  - Update CircleCI config to run Sonarscanner manually as Code coverage isn't supported by automatic analysis, see https://sonarcloud.io/documentation/advanced-setup/automatic-analysis/#prerequisites.


Result from a previous commit with duplicated lines: 
![image](https://user-images.githubusercontent.com/4112568/131466899-26b63324-ff1b-43d2-bc71-1891229ff95c.png)
