### PR TITLE
Ignore sonar-project file when checking license headers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,7 @@
             <exclude>**/*.adoc</exclude>
             <exclude>node_modules/**</exclude>
             <exclude>node/**</exclude>
+            <exclude>sonar-project.properties</exclude>
           </excludes>
         </configuration>
       </plugin>


### PR DESCRIPTION
**Issue**

NA

**Description**

Ignore sonar-project file when checking license headers
