### PR TITLE
chore: exclude `**/*.stories.ts` only for coverage

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -11,3 +11,4 @@ sonar.sourceEncoding=UTF-8
 sonar.test=src
 sonar.test.inclusions=**/*.spec.ts
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
+sonar.coverage.exclusions=**/*.stories.ts

--- a/src/organization/configuration/console/console-settings.stories.ts
+++ b/src/organization/configuration/console/console-settings.stories.ts
@@ -36,3 +36,15 @@ export const Default: Story<ConsoleSettingsComponent> = {
     },
   },
 };
+
+export const ToTestSonarCoverage: Story<ConsoleSettingsComponent> = {
+  render: (args) => ({
+    props: args,
+  }),
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/file/wKU2mCqdmzhtDKlKbh5MPL/Front_End_lib?node-id=242%3A7153',
+    },
+  },
+};


### PR DESCRIPTION
**Issue**
na

**Description**

Keep sonar fo storybook stories. but exclude for coverage 

see pb here : 
https://sonarcloud.io/component_measures?id=gravitee-io_gravitee-management-webui&metric=new_coverage&pullRequest=1669&selected=gravitee-io_gravitee-management-webui%3Asrc%2Fshared%2Fcomponents%2Fconfirm-dialog%2Fconfirm-dialog.stories.ts&view=list



**Screenshots**

na

**Additional context**
na