### PR TITLE
6061 migrate org users list

### DIFF
--- a/src/ajs-upgraded-providers.ts
+++ b/src/ajs-upgraded-providers.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Provider to temporarily ensure compatibility between AngularJs and Angular
+ */
+import { InjectionToken } from '@angular/core';
+
+export const UIRouterState = new InjectionToken('UIRouterState');
+
+function uiRouterStateServiceFactory(i: any) {
+  return i.get('$state');
+}
+export const uiRouterStateProvider = {
+  provide: UIRouterState,
+  useFactory: uiRouterStateServiceFactory,
+  deps: ['$injector'],
+};
+
+export const UIRouterStateParams = new InjectionToken('UIRouterStateParams');
+
+function uiRouterStateParamsServiceFactory(i: any) {
+  return i.get('$stateParams');
+}
+export const uiRouterStateParamsProvider = {
+  provide: UIRouterStateParams,
+  useFactory: uiRouterStateParamsServiceFactory,
+  deps: ['$injector'],
+};

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -20,6 +20,7 @@ import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { UpgradeModule } from '@angular/upgrade/static';
 
+import { uiRouterStateProvider, uiRouterStateParamsProvider } from './ajs-upgraded-providers';
 import { OrganizationSettingsModule } from './organization/configuration/organization-settings.module';
 import { httpInterceptorProviders } from './shared/interceptors/http-interceptors';
 
@@ -37,7 +38,7 @@ import { httpInterceptorProviders } from './shared/interceptors/http-interceptor
     UpgradeModule,
     OrganizationSettingsModule,
   ],
-  providers: [httpInterceptorProviders],
+  providers: [httpInterceptorProviders, uiRouterStateProvider, uiRouterStateParamsProvider],
 })
 export class AppModule {
   constructor(private upgrade: UpgradeModule) {}

--- a/src/management/management.module.ajs.ts
+++ b/src/management/management.module.ajs.ts
@@ -563,6 +563,7 @@ import '@highcharts/map-collection/custom/world';
 import { DebugApiService } from '../services/debugApi.service';
 import { downgradeComponent } from '@angular/upgrade/static';
 import { OrgSettingsGeneralComponent } from '../organization/configuration/console/org-settings-general.component';
+import { OrgSettingsUsersComponent } from '../organization/configuration/users/org-settings-users.component';
 
 (<any>window).moment = moment;
 require('angular-moment-picker');
@@ -1006,6 +1007,7 @@ graviteeManagementModule.controller('ApiLoggingController', ApiLoggingController
 
 // Users
 graviteeManagementModule.component('users', UsersComponent);
+graviteeManagementModule.directive('ngOrgSettingsUsers', downgradeComponent({ component: OrgSettingsUsersComponent }));
 graviteeManagementModule.component('userDetail', UserDetailComponent);
 graviteeManagementModule.component('newUser', NewUserComponent);
 graviteeManagementModule.controller('DialogAddUserGroupController', DialogAddUserGroupController);

--- a/src/organization/configuration/organization-settings.module.ts
+++ b/src/organization/configuration/organization-settings.module.ts
@@ -31,6 +31,7 @@ import { MatDialogModule } from '@angular/material/dialog';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 
 import { OrgSettingsGeneralComponent } from './console/org-settings-general.component';
+import { OrgSettingsUsersComponent } from './users/org-settings-users.component';
 
 import { GioConfirmDialogModule } from '../../shared/components/confirm-dialog/confirm-dialog.module';
 @NgModule({
@@ -54,8 +55,8 @@ import { GioConfirmDialogModule } from '../../shared/components/confirm-dialog/c
 
     GioConfirmDialogModule,
   ],
-  declarations: [OrgSettingsGeneralComponent],
-  exports: [OrgSettingsGeneralComponent],
-  entryComponents: [OrgSettingsGeneralComponent],
+  declarations: [OrgSettingsGeneralComponent, OrgSettingsUsersComponent],
+  exports: [OrgSettingsGeneralComponent, OrgSettingsUsersComponent],
+  entryComponents: [OrgSettingsGeneralComponent, OrgSettingsUsersComponent],
 })
 export class OrganizationSettingsModule {}

--- a/src/organization/configuration/users/org-settings-users.component.html
+++ b/src/organization/configuration/users/org-settings-users.component.html
@@ -1,0 +1,18 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+            http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<button mat-button>Basic</button>

--- a/src/organization/configuration/users/org-settings-users.component.html
+++ b/src/organization/configuration/users/org-settings-users.component.html
@@ -15,4 +15,4 @@
     limitations under the License.
 
 -->
-<button mat-button>Basic</button>
+<button mat-button (click)="nextPage()">Go to next page</button>

--- a/src/organization/configuration/users/org-settings-users.component.spec.ts
+++ b/src/organization/configuration/users/org-settings-users.component.spec.ts
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 
-import { OrganizationSettingsModule } from '../organization-settings.module';
 import { OrgSettingsUsersComponent } from './org-settings-users.component';
+
+import { UIRouterStateParams, UIRouterState } from '../../../ajs-upgraded-providers';
+import { OrganizationSettingsModule } from '../organization-settings.module';
 
 describe('OrgSettingsUsersComponent', () => {
   let component: OrgSettingsUsersComponent;
@@ -26,6 +27,10 @@ describe('OrgSettingsUsersComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [OrganizationSettingsModule],
+      providers: [
+        { provide: UIRouterState, useValue: { go: jest.fn() } },
+        { provide: UIRouterStateParams, useValue: {} },
+      ],
     });
     fixture = TestBed.createComponent(OrgSettingsUsersComponent);
     component = fixture.componentInstance;

--- a/src/organization/configuration/users/org-settings-users.component.spec.ts
+++ b/src/organization/configuration/users/org-settings-users.component.spec.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+
+import { OrganizationSettingsModule } from '../organization-settings.module';
+import { OrgSettingsUsersComponent } from './org-settings-users.component';
+
+describe('OrgSettingsUsersComponent', () => {
+  let component: OrgSettingsUsersComponent;
+  let fixture: ComponentFixture<OrgSettingsUsersComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [OrganizationSettingsModule],
+    });
+    fixture = TestBed.createComponent(OrgSettingsUsersComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should init correctly', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/organization/configuration/users/org-settings-users.component.ts
+++ b/src/organization/configuration/users/org-settings-users.component.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'org-settings-users',
+  styles: [require('./org-settings-users.component.scss')],
+  template: require('./org-settings-users.component.html'),
+})
+export class OrgSettingsUsersComponent {}

--- a/src/organization/configuration/users/org-settings-users.component.ts
+++ b/src/organization/configuration/users/org-settings-users.component.ts
@@ -13,11 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component } from '@angular/core';
+import { Component, Inject } from '@angular/core';
+import { StateService } from '@uirouter/core';
+
+import { UIRouterStateParams, UIRouterState } from '../../../ajs-upgraded-providers';
 
 @Component({
   selector: 'org-settings-users',
   styles: [require('./org-settings-users.component.scss')],
   template: require('./org-settings-users.component.html'),
 })
-export class OrgSettingsUsersComponent {}
+export class OrgSettingsUsersComponent {
+  page = 0;
+  constructor(@Inject(UIRouterStateParams) private $stateParams, @Inject(UIRouterState) private $state: StateService) {}
+
+  ngOnInit() {
+    this.page = this.$stateParams?.page ?? 0;
+  }
+
+  nextPage() {
+    this.$state.go('organization.settings.ng-users', { page: this.page++ });
+  }
+}

--- a/src/organization/organization.route.ajs.ts
+++ b/src/organization/organization.route.ajs.ts
@@ -198,6 +198,30 @@ function organizationRouterConfig($stateProvider) {
         },
       },
     })
+    .state('organization.settings.ng-users', {
+      url: '/ng-users?q&page',
+      component: 'ngOrgSettingsUsers',
+      resolve: {
+        usersPage: (UserService: UserService, $state, $stateParams) =>
+          UserService.list($stateParams.q, $stateParams.page).then((response) => response.data),
+      },
+      data: {
+        useAngularMaterial: true,
+        menu: null,
+        docs: {
+          page: 'organization-configuration-users',
+        },
+        perms: {
+          only: ['organization-user-c', 'organization-user-r', 'organization-user-u', 'organization-user-d'],
+        },
+      },
+      params: {
+        page: {
+          value: '1',
+          dynamic: true,
+        },
+      },
+    })
     .state('organization.settings.user', {
       url: '/users/:userId',
       component: 'userDetail',


### PR DESCRIPTION
**Issue**
https://github.com/gravitee-io/issues/issues/6061

**Description**

Start migration of organization users page with only empty component and useful provider to handle AngularJs states $ routeStates

**Screenshots**
na

**Additional context**

The first PR of a long series to avoid a big PR for one screen

