### PR TITLE
fix: Upgrade Nginx base image and upgrade libgcrypt

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM nginx:1.19-alpine
+FROM nginx:1.21-alpine
 LABEL maintainer="contact@graviteesource.com"
 
 ARG GRAVITEEIO_VERSION=0
@@ -27,6 +27,7 @@ ENV WWW_TARGET /usr/share/nginx/html
 
 RUN apk update \
   && apk add --update --no-cache zip unzip netcat-openbsd wget \
+  && apk add --upgrade --no-cache libgcrypt \
   && wget ${GRAVITEEIO_DOWNLOAD_URL}/graviteeio-full-${GRAVITEEIO_VERSION}.zip -P /tmp \
   && unzip /tmp/graviteeio-full-${GRAVITEEIO_VERSION}.zip -d /tmp/ \
   && apk del zip unzip netcat-openbsd wget \


### PR DESCRIPTION
Closes gravitee-io/issues#6139
