### PR TITLE
feat: handle duplicate api keys

### DIFF
--- a/src/management/api/portal/subscriptions/components/apiKeyValidatedInput.component.ts
+++ b/src/management/api/portal/subscriptions/components/apiKeyValidatedInput.component.ts
@@ -25,6 +25,7 @@ export enum CustomApiKeyInputState {
 const ApiKeyValidatedInput: ng.IComponentOptions = {
   bindings: {
     apiId: '<',
+    applicationId: '<',
     formReference: '<',
     label: '<',
     onChange: '<',
@@ -46,8 +47,8 @@ const ApiKeyValidatedInput: ng.IComponentOptions = {
     };
 
     this.checkApiKeyUnicity = (apiKey: string) => {
-      if (apiKey && apiKey.length > 0) {
-        ApiService.verifyApiKey(this.apiId, apiKey).then(
+      if (apiKey?.length > 0 && this.apiId && this.applicationId) {
+        ApiService.verifyApiKey(this.apiId, this.applicationId, apiKey).then(
           (response) => {
             if (response && response.data) {
               this.state = CustomApiKeyInputState.VALID;

--- a/src/management/api/portal/subscriptions/dialog/subscription.accept.dialog.controller.ts
+++ b/src/management/api/portal/subscriptions/dialog/subscription.accept.dialog.controller.ts
@@ -21,6 +21,7 @@ function DialogSubscriptionAcceptController($scope, $mdDialog, locals) {
   $scope.now = moment().toDate();
   $scope.canUseCustomApiKey = locals.canUseCustomApiKey;
   $scope.apiId = locals.apiId;
+  $scope.applicationId = locals.applicationId;
 
   this.customApiKey = null;
 

--- a/src/management/api/portal/subscriptions/dialog/subscription.accept.dialog.html
+++ b/src/management/api/portal/subscriptions/dialog/subscription.accept.dialog.html
@@ -42,6 +42,7 @@
             <api-key-validated-input
               form-reference="SubscriptionForm"
               api-id="apiId"
+              application-id="applicationId"
               on-change="dialogSubscriptionAcceptController.onApiKeyValueChange"
             ></api-key-validated-input>
           </div>

--- a/src/management/api/portal/subscriptions/dialog/subscription.create.dialog.html
+++ b/src/management/api/portal/subscriptions/dialog/subscription.create.dialog.html
@@ -70,6 +70,7 @@
               <api-key-validated-input
                 form-reference="CustomApiKeyForm"
                 api-id="dialogSubscriptionCreateController.api.id"
+                application-id="dialogSubscriptionCreateController.selectedApp.id"
                 label="'You can provide a custom API key if you already have one'"
                 on-change="dialogSubscriptionCreateController.onApiKeyValueChange"
               ></api-key-validated-input>

--- a/src/management/api/portal/subscriptions/dialog/subscription.renew.dialog.controller.ts
+++ b/src/management/api/portal/subscriptions/dialog/subscription.renew.dialog.controller.ts
@@ -23,6 +23,7 @@ function DialogSubscriptionRenewController($scope, $mdDialog, locals) {
   $scope.confirmButton = locals.confirmButton || 'OK';
   $scope.cancelButton = locals.cancelButton || 'Cancel';
   $scope.apiId = locals.apiId;
+  $scope.applicationId = locals.applicationId;
   this.selectedPlanCustomApiKey = null;
   this.customValue = '';
 

--- a/src/management/api/portal/subscriptions/dialog/subscription.renew.dialog.html
+++ b/src/management/api/portal/subscriptions/dialog/subscription.renew.dialog.html
@@ -25,6 +25,7 @@
         <api-key-validated-input
           form-reference="CustomApiKeyForm"
           api-id="apiId"
+          application-id="applicationId"
           on-change="ctrl.onApiKeyValueChange"
         ></api-key-validated-input>
       </div>

--- a/src/management/api/portal/subscriptions/subscription.component.ts
+++ b/src/management/api/portal/subscriptions/subscription.component.ts
@@ -176,6 +176,7 @@ const ApiSubscriptionComponent: ng.IComponentOptions = {
           clickOutsideToClose: true,
           locals: {
             apiId: this.api.id,
+            applicationId: this.subscription.application.id,
             canUseCustomApiKey: this.canUseCustomApiKey,
           },
         })
@@ -217,6 +218,7 @@ const ApiSubscriptionComponent: ng.IComponentOptions = {
             customMessage: this.canUseCustomApiKey ? 'You can provide a custom API key here' : null,
             confirmButton: 'Renew',
             apiId: this.api.id,
+            applicationId: this.subscription.application.id,
           },
         })
         .then((response) => {
@@ -237,14 +239,14 @@ const ApiSubscriptionComponent: ng.IComponentOptions = {
           template: require('../../../../components/dialog/confirmWarning.dialog.html'),
           clickOutsideToClose: true,
           locals: {
-            title: "Are you sure you want to revoke API Key '" + apiKey + "'?",
+            title: "Are you sure you want to revoke API Key '" + apiKey.key + "'?",
             confirmButton: 'Revoke',
           },
         })
         .then((response) => {
           if (response) {
-            this.ApiService.revokeApiKey(this.api.id, this.subscription.id, apiKey).then(() => {
-              this.NotificationService.show('API Key ' + apiKey + ' has been revoked!');
+            this.ApiService.revokeApiKey(this.api.id, this.subscription.id, apiKey.id).then(() => {
+              this.NotificationService.show('API Key ' + apiKey.key + ' has been revoked!');
               this.listApiKeys();
             });
           }
@@ -265,7 +267,7 @@ const ApiSubscriptionComponent: ng.IComponentOptions = {
         .then((expirationDate) => {
           apiKey.expire_at = expirationDate;
 
-          this.ApiService.updateApiKey(this.api.id, apiKey).then(() => {
+          this.ApiService.updateApiKey(this.api.id, this.subscription.id, apiKey).then(() => {
             this.NotificationService.show('An expiration date has been defined for API Key.');
             this.listApiKeys();
           });
@@ -280,14 +282,14 @@ const ApiSubscriptionComponent: ng.IComponentOptions = {
           template: require('../../../../components/dialog/confirm.dialog.html'),
           clickOutsideToClose: true,
           locals: {
-            title: "Are you sure you want to reactivate API Key '" + apiKey + "'?",
+            title: "Are you sure you want to reactivate API Key '" + apiKey.key + "'?",
             confirmButton: 'Reactivate',
           },
         })
         .then((response) => {
           if (response) {
-            this.ApiService.reactivateApiKey(this.api.id, this.subscription.id, apiKey).then(() => {
-              this.NotificationService.show('API Key ' + apiKey + ' has been reactivated!');
+            this.ApiService.reactivateApiKey(this.api.id, this.subscription.id, apiKey.id).then(() => {
+              this.NotificationService.show('API Key ' + apiKey.key + ' has been reactivated!');
               this.listApiKeys();
             });
           }

--- a/src/management/api/portal/subscriptions/subscription.html
+++ b/src/management/api/portal/subscriptions/subscription.html
@@ -204,7 +204,7 @@
                     permission-only="'api-subscription-u'"
                     style="top: 0"
                     icon="not_interested"
-                    ng-click="$ctrl.revokeApiKey(key.key)"
+                    ng-click="$ctrl.revokeApiKey(key)"
                   ></ng-md-icon>
                 </span>
                 <span ng-if="$ctrl.isValid(key) && $ctrl.subscription.status === 'ACCEPTED'">
@@ -224,7 +224,7 @@
                     permission-only="'api-subscription-u'"
                     style="top: 0"
                     icon="restore"
-                    ng-click="$ctrl.reactivateApiKey(key.key)"
+                    ng-click="$ctrl.reactivateApiKey(key)"
                   ></ng-md-icon>
                 </span>
               </td>

--- a/src/management/application/details/subscriptions/application-subscription.component.ts
+++ b/src/management/application/details/subscriptions/application-subscription.component.ts
@@ -91,14 +91,14 @@ const ApplicationSubscriptionComponent: ng.IComponentOptions = {
           template: require('../../../../components/dialog/confirmWarning.dialog.html'),
           clickOutsideToClose: true,
           locals: {
-            title: "Are you sure you want to revoke API Key '" + apiKey + "'?",
+            title: "Are you sure you want to revoke API Key '" + apiKey.key + "'?",
             confirmButton: 'Revoke',
           },
         })
         .then((response) => {
           if (response) {
-            this.ApplicationService.revokeApiKey(this.application.id, this.subscription.id, apiKey).then(() => {
-              this.NotificationService.show('API Key ' + apiKey + ' has been revoked!');
+            this.ApplicationService.revokeApiKey(this.application.id, this.subscription.id, apiKey.id).then(() => {
+              this.NotificationService.show('API Key ' + apiKey.key + ' has been revoked!');
               this.listApiKeys();
             });
           }

--- a/src/management/application/details/subscriptions/application-subscription.html
+++ b/src/management/application/details/subscriptions/application-subscription.html
@@ -139,7 +139,7 @@
                     permission-only="'api-subscription-u'"
                     style="top: 0"
                     icon="not_interested"
-                    ng-click="$ctrl.revokeApiKey(key.key)"
+                    ng-click="$ctrl.revokeApiKey(key)"
                   ></ng-md-icon>
                 </span>
               </td>

--- a/src/management/application/details/subscriptions/application-subscriptions.controller.ts
+++ b/src/management/application/details/subscriptions/application-subscriptions.controller.ts
@@ -188,14 +188,14 @@ class ApplicationSubscriptionsController {
         template: require('../../../../components/dialog/confirmWarning.dialog.html'),
         clickOutsideToClose: true,
         locals: {
-          title: "Are you sure you want to revoke API Key '" + apiKey + "'?",
+          title: "Are you sure you want to revoke API Key '" + apiKey.key + "'?",
           confirmButton: 'Revoke',
         },
       })
       .then((response) => {
         if (response) {
-          this.ApplicationService.revokeApiKey(this.application.id, subscription.id, apiKey).then(() => {
-            this.NotificationService.show('API Key ' + apiKey + ' has been revoked !');
+          this.ApplicationService.revokeApiKey(this.application.id, subscription.id, apiKey.id).then(() => {
+            this.NotificationService.show('API Key ' + apiKey.key + ' has been revoked !');
             this.listApiKeys(subscription);
           });
         }
@@ -228,7 +228,7 @@ class ApplicationSubscriptionsController {
   }
   */
 
-  showExpirationModal(apiId, apiKey) {
+  showExpirationModal(apiId, subscriptionId, apiKey) {
     this.$mdDialog
       .show({
         controller: 'DialogApiKeyExpirationController',
@@ -239,7 +239,7 @@ class ApplicationSubscriptionsController {
       .then((expirationDate) => {
         apiKey.expire_at = expirationDate;
 
-        this.ApiService.updateApiKey(apiId, apiKey).then(() => {
+        this.ApiService.updateApiKey(apiId, subscriptionId, apiKey).then(() => {
           this.NotificationService.show('An expiration date has been settled for API Key');
         });
       });

--- a/src/services/api.service.ts
+++ b/src/services/api.service.ts
@@ -524,15 +524,18 @@ export class ApiService {
   }
 
   listApiKeys(apiId: string, subscriptionId: string): IHttpPromise<any> {
-    return this.$http.get(`${this.Constants.env.baseURL}/apis/${apiId}/subscriptions/${subscriptionId}/keys`);
+    return this.$http.get(`${this.Constants.env.baseURL}/apis/${apiId}/subscriptions/${subscriptionId}/apikeys`);
   }
 
-  revokeApiKey(apiId: string, subscriptionId: string, apiKey: string): IHttpPromise<any> {
-    return this.$http.delete(`${this.Constants.env.baseURL}/apis/${apiId}/subscriptions/${subscriptionId}/keys/${apiKey}`);
+  revokeApiKey(apiId: string, subscriptionId: string, apiKeyId: string): IHttpPromise<any> {
+    return this.$http.delete(`${this.Constants.env.baseURL}/apis/${apiId}/subscriptions/${subscriptionId}/apikeys/${apiKeyId}`);
   }
 
-  reactivateApiKey(apiId: string, subscriptionId: string, apiKey: string): IHttpPromise<any> {
-    return this.$http.post(`${this.Constants.env.baseURL}/apis/${apiId}/subscriptions/${subscriptionId}/keys/${apiKey}/_reactivate`, '');
+  reactivateApiKey(apiId: string, subscriptionId: string, apiKeyId: string): IHttpPromise<any> {
+    return this.$http.post(
+      `${this.Constants.env.baseURL}/apis/${apiId}/subscriptions/${subscriptionId}/apikeys/${apiKeyId}/_reactivate`,
+      '',
+    );
   }
 
   renewApiKey(apiId: string, subscriptionId: string, customApiKey: any): IHttpPromise<any> {
@@ -541,11 +544,11 @@ export class ApiService {
         customApiKey: customApiKey,
       },
     };
-    return this.$http.post(`${this.Constants.env.baseURL}/apis/${apiId}/subscriptions/${subscriptionId}`, null, params);
+    return this.$http.post(`${this.Constants.env.baseURL}/apis/${apiId}/subscriptions/${subscriptionId}/apikeys/_renew`, null, params);
   }
 
-  updateApiKey(apiId: string, apiKey: { key: string }): IHttpPromise<any> {
-    return this.$http.put(`${this.Constants.env.baseURL}/apis/${apiId}/keys/${apiKey.key}`, apiKey);
+  updateApiKey(apiId: string, subscriptionId: string, apiKey: { id: string }): IHttpPromise<any> {
+    return this.$http.put(`${this.Constants.env.baseURL}/apis/${apiId}/subscriptions/${subscriptionId}/apikeys/${apiKey.id}`, apiKey);
   }
 
   listApiMetadata(apiId: string): IHttpPromise<any> {
@@ -721,8 +724,10 @@ export class ApiService {
   /*
    * Api Keys
    */
-  verifyApiKey(apiId: string, apiKey: string): IHttpPromise<any> {
-    return this.$http.post(`${this.Constants.env.baseURL}/apis/${apiId}/keys/_verify?apiKey=${apiKey}`, {});
+  verifyApiKey(apiId: string, applicationId: string, apiKey: string): IHttpPromise<any> {
+    return this.$http.get(`${this.Constants.env.baseURL}/apis/${apiId}/subscriptions/_canCreate`, {
+      params: { key: apiKey, application: applicationId },
+    });
   }
 
   getFlowSchemaForm(): IHttpPromise<any> {

--- a/src/services/application.service.ts
+++ b/src/services/application.service.ts
@@ -136,15 +136,15 @@ class ApplicationService {
   }
 
   listApiKeys(applicationId, subscriptionId): ng.IHttpPromise<any> {
-    return this.$http.get(this.subscriptionsURL(applicationId) + subscriptionId + '/keys');
+    return this.$http.get(this.subscriptionsURL(applicationId) + subscriptionId + '/apikeys');
   }
 
   renewApiKey(applicationId, subscriptionId) {
-    return this.$http.post(this.subscriptionsURL(applicationId) + subscriptionId, '');
+    return this.$http.post(this.subscriptionsURL(applicationId) + subscriptionId + '/apikeys/_renew', '');
   }
 
-  revokeApiKey(applicationId, subscriptionId, apiKey) {
-    return this.$http.delete(this.subscriptionsURL(applicationId) + subscriptionId + '/keys/' + apiKey);
+  revokeApiKey(applicationId, subscriptionId, apiKeyId) {
+    return this.$http.delete(this.subscriptionsURL(applicationId) + subscriptionId + '/apikeys/' + apiKeyId);
   }
 
   /*


### PR DESCRIPTION
https://github.com/gravitee-io/issues/issues/6006

Now, we permit to use the same API key for multiple subscriptions of the same application.
To know if an apiKey can be created, we have to provide 3 query parameters to the _canCreate endpoint : apiKey, apiId, and applicationId.