### PR TITLE
Fix banner size by using px instead of rem

### DIFF
--- a/src/management/api/_api.scss
+++ b/src/management/api/_api.scss
@@ -155,10 +155,10 @@
 
 .gravitee-api-banner-content {
   background: #dfa941;
-  padding: 0.5rem;
+  padding: 3px;
   text-align: center;
   color: white;
-  line-height: 0.7rem;
+  line-height: 11px;
   text-shadow: 0 1px 1px rgba(0, 0, 0, 0.25);
 }
 


### PR DESCRIPTION
**Issue**

NA

**Description**

Fix banner size by using `px` instead of `rem`

**Screenshots**

Before:

![image](https://user-images.githubusercontent.com/4112568/133980434-070a416c-502a-4a5a-a70e-a23d309165be.png)


After:

![image](https://user-images.githubusercontent.com/4112568/133980381-41f7f3c3-1413-4695-9c0e-c4f216a82d44.png)
