### PR TITLE
Improve UX of Console Setting screen 

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -72,4 +72,7 @@ module.exports = {
 
     return config;
   },
+  previewHead :(head) => (
+    `${head}
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">`)
 };

--- a/src/organization/configuration/console/org-settings-general.component.html
+++ b/src/organization/configuration/console/org-settings-general.component.html
@@ -33,7 +33,9 @@
           appearance="fill"
           class="settings-general__form__card__form-field"
         >
-          <mat-icon *ngIf="isReadonlySetting('management.title')" matPrefix>lock</mat-icon>
+          <mat-icon *ngIf="isReadonlySetting('management.title')" class="settings-general__form__card__form-field__icon" matPrefix
+            >lock</mat-icon
+          >
           <mat-label>Title</mat-label>
           <input matInput formControlName="title" />
         </mat-form-field>
@@ -44,7 +46,9 @@
           appearance="fill"
           class="settings-general__form__card__form-field"
         >
-          <mat-icon *ngIf="isReadonlySetting('management.url')" matPrefix>lock</mat-icon>
+          <mat-icon *ngIf="isReadonlySetting('management.url')" class="settings-general__form__card__form-field__icon" matPrefix
+            >lock</mat-icon
+          >
           <mat-label>Management URL</mat-label>
           <input matInput formControlName="url" />
         </mat-form-field>
@@ -115,7 +119,7 @@
           appearance="fill"
           class="settings-general__form__card__form-field"
         >
-          <mat-icon *ngIf="isReadonlySetting('theme.name')" matPrefix>lock</mat-icon>
+          <mat-icon *ngIf="isReadonlySetting('theme.name')" class="settings-general__form__card__form-field__icon" matPrefix>lock</mat-icon>
           <mat-label>Name</mat-label>
           <input matInput formControlName="name" />
         </mat-form-field>
@@ -126,7 +130,7 @@
           appearance="fill"
           class="settings-general__form__card__form-field"
         >
-          <mat-icon *ngIf="isReadonlySetting('theme.logo')" matPrefix>lock</mat-icon>
+          <mat-icon *ngIf="isReadonlySetting('theme.logo')" class="settings-general__form__card__form-field__icon" matPrefix>lock</mat-icon>
           <mat-label>Logo</mat-label>
           <input matInput formControlName="logo" />
         </mat-form-field>
@@ -137,7 +141,9 @@
           appearance="fill"
           class="settings-general__form__card__form-field"
         >
-          <mat-icon *ngIf="isReadonlySetting('theme.loader')" matPrefix>lock</mat-icon>
+          <mat-icon *ngIf="isReadonlySetting('theme.loader')" class="settings-general__form__card__form-field__icon" matPrefix
+            >lock</mat-icon
+          >
           <mat-label>Loader</mat-label>
           <input matInput formControlName="loader" />
         </mat-form-field>
@@ -153,7 +159,9 @@
           appearance="fill"
           class="settings-general__form__card__form-field"
         >
-          <mat-icon *ngIf="isReadonlySetting('scheduler.tasks')" matPrefix>lock</mat-icon>
+          <mat-icon *ngIf="isReadonlySetting('scheduler.tasks')" class="settings-general__form__card__form-field__icon" matPrefix
+            >lock</mat-icon
+          >
           <mat-label>Tasks (in seconds)</mat-label>
           <input matInput formControlName="tasks" type="number" min="0" />
         </mat-form-field>
@@ -164,7 +172,9 @@
           appearance="fill"
           class="settings-general__form__card__form-field"
         >
-          <mat-icon *ngIf="isReadonlySetting('scheduler.notifications')" matPrefix>lock</mat-icon>
+          <mat-icon *ngIf="isReadonlySetting('scheduler.notifications')" class="settings-general__form__card__form-field__icon" matPrefix
+            >lock</mat-icon
+          >
           <mat-label>Notifications (in seconds)</mat-label>
           <input #schedulerNotificationsInput matInput formControlName="notifications" type="number" min="0" />
         </mat-form-field>
@@ -197,7 +207,9 @@
           class="settings-general__form__card__form-field"
           appearance="fill"
         >
-          <mat-icon *ngIf="isReadonlySetting('cors.allowOrigin')" matPrefix>lock</mat-icon>
+          <mat-icon *ngIf="isReadonlySetting('cors.allowOrigin')" class="settings-general__form__card__form-field__icon" matPrefix
+            >lock</mat-icon
+          >
           <mat-label>Allow-Origin</mat-label>
           <mat-chip-list #allowOriginChipList aria-label="Allow-Origin selection" multiple [disabled]="allowOriginFormControl.disabled">
             <mat-chip
@@ -231,7 +243,9 @@
           class="settings-general__form__card__form-field"
           appearance="fill"
         >
-          <mat-icon *ngIf="isReadonlySetting('cors.allowMethods')" matPrefix>lock</mat-icon>
+          <mat-icon *ngIf="isReadonlySetting('cors.allowMethods')" class="settings-general__form__card__form-field__icon" matPrefix
+            >lock</mat-icon
+          >
           <mat-label>Access-Control-Allow-Methods</mat-label>
           <mat-select formControlName="allowMethods" multiple>
             <mat-option *ngFor="let method of httpMethods" [value]="method">{{ method }}</mat-option>
@@ -248,7 +262,9 @@
           class="settings-general__form__card__form-field"
           appearance="fill"
         >
-          <mat-icon *ngIf="isReadonlySetting('cors.allowHeaders')" matPrefix>lock</mat-icon>
+          <mat-icon *ngIf="isReadonlySetting('cors.allowHeaders')" class="settings-general__form__card__form-field__icon" matPrefix
+            >lock</mat-icon
+          >
           <mat-label>Allow-Headers</mat-label>
           <mat-chip-list #allowHeadersChipList aria-label="Allow-Headers selection" multiple [disabled]="allowHeadersFormControl.disabled">
             <mat-chip
@@ -287,7 +303,9 @@
           class="settings-general__form__card__form-field"
           appearance="fill"
         >
-          <mat-icon *ngIf="isReadonlySetting('cors.exposedHeaders')" matPrefix>lock</mat-icon>
+          <mat-icon *ngIf="isReadonlySetting('cors.exposedHeaders')" class="settings-general__form__card__form-field__icon" matPrefix
+            >lock</mat-icon
+          >
           <mat-label>Exposed-Headers</mat-label>
           <mat-chip-list
             #exposedHeadersChipList
@@ -330,7 +348,9 @@
           appearance="fill"
           class="settings-general__form__card__form-field"
         >
-          <mat-icon *ngIf="isReadonlySetting('cors.maxAge')" matPrefix>lock</mat-icon>
+          <mat-icon *ngIf="isReadonlySetting('cors.maxAge')" class="settings-general__form__card__form-field__icon" matPrefix
+            >lock</mat-icon
+          >
           <mat-label>Max age (seconds) <small>How long the response from a pre-flight request can be cached by clients</small></mat-label>
           <input #maxAgeInput matInput formControlName="maxAge" type="number" min="0" />
         </mat-form-field>
@@ -356,7 +376,7 @@
           appearance="fill"
           class="settings-general__form__card__form-field"
         >
-          <mat-icon *ngIf="isReadonlySetting('email.host')" matPrefix>lock</mat-icon>
+          <mat-icon *ngIf="isReadonlySetting('email.host')" class="settings-general__form__card__form-field__icon" matPrefix>lock</mat-icon>
           <mat-label>Host</mat-label>
           <input matInput formControlName="host" />
         </mat-form-field>
@@ -367,7 +387,7 @@
           appearance="fill"
           class="settings-general__form__card__form-field"
         >
-          <mat-icon *ngIf="isReadonlySetting('email.port')" matPrefix>lock</mat-icon>
+          <mat-icon *ngIf="isReadonlySetting('email.port')" class="settings-general__form__card__form-field__icon" matPrefix>lock</mat-icon>
           <mat-label>Port</mat-label>
           <input matInput formControlName="port" type="number" min="0" />
         </mat-form-field>
@@ -378,7 +398,9 @@
           appearance="fill"
           class="settings-general__form__card__form-field"
         >
-          <mat-icon *ngIf="isReadonlySetting('email.username')" matPrefix>lock</mat-icon>
+          <mat-icon *ngIf="isReadonlySetting('email.username')" class="settings-general__form__card__form-field__icon" matPrefix
+            >lock</mat-icon
+          >
           <mat-label>Username</mat-label>
           <input matInput formControlName="username" />
         </mat-form-field>
@@ -389,7 +411,9 @@
           appearance="fill"
           class="settings-general__form__card__form-field"
         >
-          <mat-icon *ngIf="isReadonlySetting('email.password')" matPrefix>lock</mat-icon>
+          <mat-icon *ngIf="isReadonlySetting('email.password')" class="settings-general__form__card__form-field__icon" matPrefix
+            >lock</mat-icon
+          >
           <mat-label>Password</mat-label>
           <input matInput formControlName="password" type="password" />
         </mat-form-field>
@@ -400,7 +424,9 @@
           appearance="fill"
           class="settings-general__form__card__form-field"
         >
-          <mat-icon *ngIf="isReadonlySetting('email.protocol')" matPrefix>lock</mat-icon>
+          <mat-icon *ngIf="isReadonlySetting('email.protocol')" class="settings-general__form__card__form-field__icon" matPrefix
+            >lock</mat-icon
+          >
           <mat-label>Protocol</mat-label>
           <input matInput formControlName="protocol" />
         </mat-form-field>
@@ -411,7 +437,9 @@
           appearance="fill"
           class="settings-general__form__card__form-field"
         >
-          <mat-icon *ngIf="isReadonlySetting('email.subject')" matPrefix>lock</mat-icon>
+          <mat-icon *ngIf="isReadonlySetting('email.subject')" class="settings-general__form__card__form-field__icon" matPrefix
+            >lock</mat-icon
+          >
           <mat-label>Subject</mat-label>
           <input matInput formControlName="subject" />
         </mat-form-field>
@@ -422,7 +450,7 @@
           appearance="fill"
           class="settings-general__form__card__form-field"
         >
-          <mat-icon *ngIf="isReadonlySetting('email.from')" matPrefix>lock</mat-icon>
+          <mat-icon *ngIf="isReadonlySetting('email.from')" class="settings-general__form__card__form-field__icon" matPrefix>lock</mat-icon>
           <mat-label>From</mat-label>
           <input matInput formControlName="from" type="email" />
         </mat-form-field>
@@ -459,7 +487,9 @@
             appearance="fill"
             class="settings-general__form__card__form-field"
           >
-            <mat-icon *ngIf="isReadonlySetting('email.sslTrust')" matPrefix>lock</mat-icon>
+            <mat-icon *ngIf="isReadonlySetting('email.sslTrust')" class="settings-general__form__card__form-field__icon" matPrefix
+              >lock</mat-icon
+            >
             <mat-label>SSL Trust</mat-label>
             <input #emailPropertiesSslTrustInput matInput formControlName="sslTrust" />
           </mat-form-field>

--- a/src/organization/configuration/console/org-settings-general.component.html
+++ b/src/organization/configuration/console/org-settings-general.component.html
@@ -284,7 +284,6 @@
               [formControl]="allowHeadersInputFormControl"
               [matAutocomplete]="auto"
               [matChipInputFor]="allowHeadersChipList"
-              [matChipInputAddOnBlur]="true"
               (matChipInputTokenEnd)="addChipToFormControl($event, 'cors.allowHeaders', allowHeadersChipList)"
             />
           </mat-chip-list>
@@ -330,7 +329,6 @@
               [formControl]="exposedHeadersInputFormControl"
               [matAutocomplete]="auto"
               [matChipInputFor]="exposedHeadersChipList"
-              [matChipInputAddOnBlur]="true"
               (matChipInputTokenEnd)="addChipToFormControl($event, 'cors.exposedHeaders', exposedHeadersChipList)"
             />
           </mat-chip-list>

--- a/src/organization/configuration/console/org-settings-general.component.html
+++ b/src/organization/configuration/console/org-settings-general.component.html
@@ -184,16 +184,18 @@
     <mat-card class="settings-general__form__card" formGroupName="alert">
       <h2 gioTableOfContents>Alerting</h2>
       <mat-card-content>
-        <section class="settings-general__form__card__checkbox-section">
-          <mat-checkbox
-            #alertCheckbox
-            aria-label="Alerting enabled"
-            formControlName="enabled"
-            [matTooltip]="providedConfigurationMessage"
-            [matTooltipDisabled]="!alertCheckbox.disabled"
-            >Enable Alerting</mat-checkbox
+        <gio-form-slide-toggle
+          [matTooltip]="providedConfigurationMessage"
+          [matTooltipDisabled]="!isReadonlySetting('alert.enabled')"
+          appearance="fill"
+          class="settings-general__form__card__form-field"
+        >
+          <mat-icon *ngIf="isReadonlySetting('alert.enabled')" class="settings-general__form__card__form-field__icon" gioFormPrefix
+            >lock</mat-icon
           >
-        </section>
+          <gio-form-label>Enable Alerting</gio-form-label>
+          <mat-slide-toggle gioFormSlideToggle formControlName="enabled" aria-label="Alerting enabled " name="alert"></mat-slide-toggle>
+        </gio-form-slide-toggle>
       </mat-card-content>
     </mat-card>
 
@@ -360,21 +362,26 @@
     <mat-card class="settings-general__form__card" formGroupName="email">
       <h2 gioTableOfContents>SMTP</h2>
       <mat-card-content>
-        <section class="settings-general__form__card__checkbox-section">
-          <mat-checkbox
-            #emailEnabledCheckbox
-            formControlName="enabled"
-            aria-label="Email enabled"
-            [matTooltip]="providedConfigurationMessage"
-            [matTooltipDisabled]="!emailEnabledCheckbox.disabled"
-            >Enable Emailing</mat-checkbox
+        <gio-form-slide-toggle
+          [matTooltip]="providedConfigurationMessage"
+          [matTooltipDisabled]="!isReadonlySetting('email.enabled')"
+          appearance="fill"
+          class="settings-general__form__card__form-field"
+        >
+          <mat-icon *ngIf="isReadonlySetting('email.enabled')" class="settings-general__form__card__form-field__icon" gioFormPrefix
+            >lock</mat-icon
           >
-        </section>
+          <gio-form-label>Enable Emailing</gio-form-label>
+          <mat-slide-toggle gioFormSlideToggle formControlName="enabled" aria-label="Email enabled" name="emailEnabled"></mat-slide-toggle>
+        </gio-form-slide-toggle>
+
+        <mat-divider></mat-divider>
+
         <mat-form-field
           [matTooltip]="providedConfigurationMessage"
           [matTooltipDisabled]="!isReadonlySetting('email.host')"
           appearance="fill"
-          class="settings-general__form__card__form-field"
+          class="settings-general__form__card__form-field margin-top"
         >
           <mat-icon *ngIf="isReadonlySetting('email.host')" class="settings-general__form__card__form-field__icon" matPrefix>lock</mat-icon>
           <mat-label>Host</mat-label>
@@ -455,37 +462,61 @@
           <input matInput formControlName="from" type="email" />
         </mat-form-field>
 
-        <mat-divider [inset]="true"></mat-divider>
+        <mat-divider></mat-divider>
 
-        <h3>Mail properties</h3>
+        <h3 class="settings-general__form__card__h3">Mail properties</h3>
         <ng-container formGroupName="properties">
-          <section class="settings-general__form__card__checkbox-section">
-            <mat-checkbox
-              #emailPropertiesAuthCheckbox
+          <gio-form-slide-toggle
+            [matTooltip]="providedConfigurationMessage"
+            [matTooltipDisabled]="!isReadonlySetting('email.properties.auth')"
+            appearance="fill"
+            class="settings-general__form__card__form-field"
+          >
+            <mat-icon
+              *ngIf="isReadonlySetting('email.properties.auth')"
+              class="settings-general__form__card__form-field__icon"
+              gioFormPrefix
+              >lock</mat-icon
+            >
+            <gio-form-label>Enable Auth</gio-form-label>
+            <mat-slide-toggle
+              gioFormSlideToggle
               formControlName="auth"
               aria-label="Alerting enabled"
-              [matTooltip]="providedConfigurationMessage"
-              [matTooltipDisabled]="!emailPropertiesAuthCheckbox.disabled"
-              >Enable Auth</mat-checkbox
-            >
-          </section>
+              name="emailPropertiesAuth"
+            ></mat-slide-toggle>
+          </gio-form-slide-toggle>
 
-          <section class="settings-general__form__card__checkbox-section">
-            <mat-checkbox
-              #emailPropertiesStartTlsEnableCheckbox
+          <mat-divider></mat-divider>
+
+          <gio-form-slide-toggle
+            [matTooltip]="providedConfigurationMessage"
+            [matTooltipDisabled]="!isReadonlySetting('email.properties.startTlsEnable')"
+            appearance="fill"
+            class="settings-general__form__card__form-field"
+          >
+            <mat-icon
+              *ngIf="isReadonlySetting('email.properties.startTlsEnable')"
+              class="settings-general__form__card__form-field__icon"
+              gioFormPrefix
+              >lock</mat-icon
+            >
+            <gio-form-label>Enable Start TLS</gio-form-label>
+            <mat-slide-toggle
+              gioFormSlideToggle
               formControlName="startTlsEnable"
               aria-label="Start TLS enabled"
-              [matTooltip]="providedConfigurationMessage"
-              [matTooltipDisabled]="!emailPropertiesStartTlsEnableCheckbox.disabled"
-              >Enable Start TLS</mat-checkbox
-            >
-          </section>
+              name="emailPropertiesStartTlsEnable"
+            ></mat-slide-toggle>
+          </gio-form-slide-toggle>
+
+          <mat-divider></mat-divider>
 
           <mat-form-field
             [matTooltip]="providedConfigurationMessage"
             [matTooltipDisabled]="!isReadonlySetting('email.sslTrust')"
             appearance="fill"
-            class="settings-general__form__card__form-field"
+            class="settings-general__form__card__form-field margin-top"
           >
             <mat-icon *ngIf="isReadonlySetting('email.sslTrust')" class="settings-general__form__card__form-field__icon" matPrefix
               >lock</mat-icon

--- a/src/organization/configuration/console/org-settings-general.component.html
+++ b/src/organization/configuration/console/org-settings-general.component.html
@@ -51,14 +51,28 @@
 
         <mat-divider></mat-divider>
 
-        <gio-form-slide-toggle appearance="fill" class="settings-general__form__card__form-field" formGroupName="support">
+        <gio-form-slide-toggle
+          [matTooltip]="providedConfigurationMessage"
+          [matTooltipDisabled]="!isReadonlySetting('management.support.enabled')"
+          appearance="fill"
+          class="settings-general__form__card__form-field"
+          formGroupName="support"
+        >
+          <mat-icon *ngIf="isReadonlySetting('management.support.enabled')" gioFormPrefix>lock</mat-icon>
           <gio-form-label>Activate Support</gio-form-label>
           <mat-slide-toggle gioFormSlideToggle formControlName="enabled" aria-label="Activate Support" name="support"></mat-slide-toggle>
         </gio-form-slide-toggle>
 
         <mat-divider></mat-divider>
 
-        <gio-form-slide-toggle appearance="fill" class="settings-general__form__card__form-field" formGroupName="userCreation">
+        <gio-form-slide-toggle
+          [matTooltip]="providedConfigurationMessage"
+          [matTooltipDisabled]="!isReadonlySetting('management.userCreation.enabled')"
+          appearance="fill"
+          class="settings-general__form__card__form-field"
+          formGroupName="userCreation"
+        >
+          <mat-icon *ngIf="isReadonlySetting('management.userCreation.enabled')" gioFormPrefix>lock</mat-icon>
           <gio-form-label>Allow User Registration</gio-form-label>
           <mat-slide-toggle
             #managementUserCreationSlideToggle
@@ -72,7 +86,14 @@
         <ng-container *ngIf="managementUserCreationSlideToggle.checked">
           <mat-divider></mat-divider>
 
-          <gio-form-slide-toggle appearance="fill" class="settings-general__form__card__form-field" formGroupName="automaticValidation">
+          <gio-form-slide-toggle
+            [matTooltip]="providedConfigurationMessage"
+            [matTooltipDisabled]="!isReadonlySetting('management.automaticValidation.enabled')"
+            appearance="fill"
+            class="settings-general__form__card__form-field"
+            formGroupName="automaticValidation"
+          >
+            <mat-icon *ngIf="isReadonlySetting('management.automaticValidation.enabled')" gioFormPrefix>lock</mat-icon>
             <gio-form-label>Enable automatic validation of registration requests</gio-form-label>
             <mat-slide-toggle
               gioFormSlideToggle

--- a/src/organization/configuration/console/org-settings-general.component.html
+++ b/src/organization/configuration/console/org-settings-general.component.html
@@ -27,28 +27,38 @@
       <h2 gioTableOfContents>Management</h2>
 
       <mat-card-content>
-        <mat-form-field appearance="fill" class="settings-general__form__card__form-field">
+        <mat-form-field
+          [matTooltip]="providedConfigurationMessage"
+          [matTooltipDisabled]="!isReadonlySetting('management.title')"
+          appearance="fill"
+          class="settings-general__form__card__form-field"
+        >
+          <mat-icon *ngIf="isReadonlySetting('management.title')" matPrefix>lock</mat-icon>
           <mat-label>Title</mat-label>
-          <input #managementTitleInput matInput formControlName="title" />
-          <mat-icon *ngIf="managementTitleInput.disabled" matSuffix [matTooltip]="providedConfigurationMessage">lock</mat-icon>
+          <input matInput formControlName="title" />
         </mat-form-field>
 
-        <mat-form-field appearance="fill" class="settings-general__form__card__form-field">
+        <mat-form-field
+          [matTooltip]="providedConfigurationMessage"
+          [matTooltipDisabled]="!isReadonlySetting('management.url')"
+          appearance="fill"
+          class="settings-general__form__card__form-field"
+        >
+          <mat-icon *ngIf="isReadonlySetting('management.url')" matPrefix>lock</mat-icon>
           <mat-label>Management URL</mat-label>
-          <input #managementUrlInput matInput formControlName="url" />
-          <mat-icon *ngIf="managementUrlInput.disabled" matSuffix [matTooltip]="providedConfigurationMessage">lock</mat-icon>
+          <input matInput formControlName="url" />
         </mat-form-field>
 
         <mat-divider></mat-divider>
 
-        <gio-form-slide-toggle appearance="fill" class="console-settings__card__form-field" formGroupName="support">
+        <gio-form-slide-toggle appearance="fill" class="settings-general__form__card__form-field" formGroupName="support">
           <gio-form-label>Activate Support</gio-form-label>
           <mat-slide-toggle gioFormSlideToggle formControlName="enabled" aria-label="Activate Support" name="support"></mat-slide-toggle>
         </gio-form-slide-toggle>
 
         <mat-divider></mat-divider>
 
-        <gio-form-slide-toggle appearance="fill" class="console-settings__card__form-field" formGroupName="userCreation">
+        <gio-form-slide-toggle appearance="fill" class="settings-general__form__card__form-field" formGroupName="userCreation">
           <gio-form-label>Allow User Registration</gio-form-label>
           <mat-slide-toggle
             #managementUserCreationSlideToggle
@@ -62,7 +72,7 @@
         <ng-container *ngIf="managementUserCreationSlideToggle.checked">
           <mat-divider></mat-divider>
 
-          <gio-form-slide-toggle appearance="fill" class="console-settings__card__form-field" formGroupName="automaticValidation">
+          <gio-form-slide-toggle appearance="fill" class="settings-general__form__card__form-field" formGroupName="automaticValidation">
             <gio-form-label>Enable automatic validation of registration requests</gio-form-label>
             <mat-slide-toggle
               gioFormSlideToggle
@@ -78,22 +88,37 @@
     <mat-card class="settings-general__form__card" formGroupName="theme">
       <h2 gioTableOfContents>Theme</h2>
       <mat-card-content>
-        <mat-form-field appearance="fill" class="settings-general__form__card__form-field">
+        <mat-form-field
+          [matTooltip]="providedConfigurationMessage"
+          [matTooltipDisabled]="!isReadonlySetting('theme.name')"
+          appearance="fill"
+          class="settings-general__form__card__form-field"
+        >
+          <mat-icon *ngIf="isReadonlySetting('theme.name')" matPrefix>lock</mat-icon>
           <mat-label>Name</mat-label>
-          <input #themeNameInput matInput formControlName="name" />
-          <mat-icon *ngIf="themeNameInput.disabled" matSuffix [matTooltip]="providedConfigurationMessage">lock</mat-icon>
+          <input matInput formControlName="name" />
         </mat-form-field>
 
-        <mat-form-field appearance="fill" class="settings-general__form__card__form-field">
+        <mat-form-field
+          [matTooltip]="providedConfigurationMessage"
+          [matTooltipDisabled]="!isReadonlySetting('theme.logo')"
+          appearance="fill"
+          class="settings-general__form__card__form-field"
+        >
+          <mat-icon *ngIf="isReadonlySetting('theme.logo')" matPrefix>lock</mat-icon>
           <mat-label>Logo</mat-label>
-          <input #themeLogoInput matInput formControlName="logo" />
-          <mat-icon *ngIf="themeLogoInput.disabled" matSuffix [matTooltip]="providedConfigurationMessage">lock</mat-icon>
+          <input matInput formControlName="logo" />
         </mat-form-field>
 
-        <mat-form-field appearance="fill" class="settings-general__form__card__form-field">
+        <mat-form-field
+          [matTooltip]="providedConfigurationMessage"
+          [matTooltipDisabled]="!isReadonlySetting('theme.loader')"
+          appearance="fill"
+          class="settings-general__form__card__form-field"
+        >
+          <mat-icon *ngIf="isReadonlySetting('theme.loader')" matPrefix>lock</mat-icon>
           <mat-label>Loader</mat-label>
-          <input #themeLoaderInput matInput formControlName="loader" />
-          <mat-icon *ngIf="themeLoaderInput.disabled" matSuffix [matTooltip]="providedConfigurationMessage">lock</mat-icon>
+          <input matInput formControlName="loader" />
         </mat-form-field>
       </mat-card-content>
     </mat-card>
@@ -101,16 +126,26 @@
     <mat-card class="settings-general__form__card" formGroupName="scheduler">
       <h2 gioTableOfContents>Schedulers</h2>
       <mat-card-content>
-        <mat-form-field appearance="fill" class="settings-general__form__card__form-field">
+        <mat-form-field
+          [matTooltip]="providedConfigurationMessage"
+          [matTooltipDisabled]="!isReadonlySetting('scheduler.tasks')"
+          appearance="fill"
+          class="settings-general__form__card__form-field"
+        >
+          <mat-icon *ngIf="isReadonlySetting('scheduler.tasks')" matPrefix>lock</mat-icon>
           <mat-label>Tasks (in seconds)</mat-label>
-          <input #schedulerTasksInput matInput formControlName="tasks" type="number" min="0" />
-          <mat-icon *ngIf="schedulerTasksInput.disabled" matSuffix [matTooltip]="providedConfigurationMessage">lock</mat-icon>
+          <input matInput formControlName="tasks" type="number" min="0" />
         </mat-form-field>
 
-        <mat-form-field appearance="fill" class="settings-general__form__card__form-field">
+        <mat-form-field
+          [matTooltip]="providedConfigurationMessage"
+          [matTooltipDisabled]="!isReadonlySetting('scheduler.notifications')"
+          appearance="fill"
+          class="settings-general__form__card__form-field"
+        >
+          <mat-icon *ngIf="isReadonlySetting('scheduler.notifications')" matPrefix>lock</mat-icon>
           <mat-label>Notifications (in seconds)</mat-label>
           <input #schedulerNotificationsInput matInput formControlName="notifications" type="number" min="0" />
-          <mat-icon *ngIf="schedulerNotificationsInput.disabled" matSuffix [matTooltip]="providedConfigurationMessage">lock</mat-icon>
         </mat-form-field>
       </mat-card-content>
     </mat-card>
@@ -136,9 +171,12 @@
       <mat-card-content>
         <mat-form-field
           *ngIf="formSettings.get('cors.allowOrigin'); let allowOriginFormControl"
+          [matTooltip]="providedConfigurationMessage"
+          [matTooltipDisabled]="!isReadonlySetting('cors.allowOrigin')"
           class="settings-general__form__card__form-field"
           appearance="fill"
         >
+          <mat-icon *ngIf="isReadonlySetting('cors.allowOrigin')" matPrefix>lock</mat-icon>
           <mat-label>Allow-Origin</mat-label>
           <mat-chip-list #allowOriginChipList aria-label="Allow-Origin selection" multiple [disabled]="allowOriginFormControl.disabled">
             <mat-chip
@@ -152,7 +190,6 @@
             </mat-chip>
             <input
               *ngIf="!allowOriginFormControl.disabled"
-              #allowOriginInput
               placeholder="*, https://mydomain.com, (http|https).*.mydomain.com, ..."
               [matChipInputFor]="allowOriginChipList"
               [matChipInputAddOnBlur]="true"
@@ -165,25 +202,32 @@
             <em>same-origin</em> definition.<br />
             If you choose to enable '*' it means that is allows all requests, regardless of origin. Regular Expressions are also supported.
           </mat-hint>
-          <mat-icon *ngIf="allowOriginFormControl.disabled" matSuffix [matTooltip]="providedConfigurationMessage">lock</mat-icon>
         </mat-form-field>
 
-        <mat-form-field class="settings-general__form__card__form-field" appearance="fill">
+        <mat-form-field
+          [matTooltip]="providedConfigurationMessage"
+          [matTooltipDisabled]="!isReadonlySetting('cors.allowMethods')"
+          class="settings-general__form__card__form-field"
+          appearance="fill"
+        >
+          <mat-icon *ngIf="isReadonlySetting('cors.allowMethods')" matPrefix>lock</mat-icon>
           <mat-label>Access-Control-Allow-Methods</mat-label>
-          <mat-select #allowMethodsSelect formControlName="allowMethods" multiple>
+          <mat-select formControlName="allowMethods" multiple>
             <mat-option *ngFor="let method of httpMethods" [value]="method">{{ method }}</mat-option>
           </mat-select>
           <mat-hint>
             Specifies the method or methods allowed when accessing the resource. This is used in response to a preflight request.
           </mat-hint>
-          <mat-icon *ngIf="allowMethodsSelect.disabled" matSuffix [matTooltip]="providedConfigurationMessage">lock</mat-icon>
         </mat-form-field>
 
         <mat-form-field
           *ngIf="formSettings.get('cors.allowHeaders'); let allowHeadersFormControl"
+          [matTooltip]="providedConfigurationMessage"
+          [matTooltipDisabled]="!isReadonlySetting('cors.allowHeaders')"
           class="settings-general__form__card__form-field"
           appearance="fill"
         >
+          <mat-icon *ngIf="isReadonlySetting('cors.allowHeaders')" matPrefix>lock</mat-icon>
           <mat-label>Allow-Headers</mat-label>
           <mat-chip-list #allowHeadersChipList aria-label="Allow-Headers selection" multiple [disabled]="allowHeadersFormControl.disabled">
             <mat-chip
@@ -213,14 +257,16 @@
           <mat-hint>
             Used in response to a preflight request to indicate which HTTP headers can be used when making the actual request.
           </mat-hint>
-          <mat-icon *ngIf="allowHeadersFormControl.disabled" matSuffix [matTooltip]="providedConfigurationMessage">lock</mat-icon>
         </mat-form-field>
 
         <mat-form-field
           *ngIf="formSettings.get('cors.exposedHeaders'); let exposedHeadersFormControl"
+          [matTooltip]="providedConfigurationMessage"
+          [matTooltipDisabled]="!isReadonlySetting('cors.exposedHeaders')"
           class="settings-general__form__card__form-field"
           appearance="fill"
         >
+          <mat-icon *ngIf="isReadonlySetting('cors.exposedHeaders')" matPrefix>lock</mat-icon>
           <mat-label>Exposed-Headers</mat-label>
           <mat-chip-list
             #exposedHeadersChipList
@@ -255,13 +301,17 @@
           <mat-hint>
             Used in response to a preflight request to indicate which HTTP headers can be used when making the actual request.
           </mat-hint>
-          <mat-icon *ngIf="exposedHeadersFormControl.disabled" matSuffix [matTooltip]="providedConfigurationMessage">lock</mat-icon>
         </mat-form-field>
 
-        <mat-form-field appearance="fill" class="settings-general__form__card__form-field">
+        <mat-form-field
+          [matTooltip]="providedConfigurationMessage"
+          [matTooltipDisabled]="!isReadonlySetting('cors.maxAge')"
+          appearance="fill"
+          class="settings-general__form__card__form-field"
+        >
+          <mat-icon *ngIf="isReadonlySetting('cors.maxAge')" matPrefix>lock</mat-icon>
           <mat-label>Max age (seconds) <small>How long the response from a pre-flight request can be cached by clients</small></mat-label>
           <input #maxAgeInput matInput formControlName="maxAge" type="number" min="0" />
-          <mat-icon *ngIf="maxAgeInput.disabled" matSuffix [matTooltip]="providedConfigurationMessage">lock</mat-icon>
         </mat-form-field>
       </mat-card-content>
     </mat-card>
@@ -279,46 +329,81 @@
             >Enable Emailing</mat-checkbox
           >
         </section>
-        <mat-form-field appearance="fill" class="settings-general__form__card__form-field">
+        <mat-form-field
+          [matTooltip]="providedConfigurationMessage"
+          [matTooltipDisabled]="!isReadonlySetting('email.host')"
+          appearance="fill"
+          class="settings-general__form__card__form-field"
+        >
+          <mat-icon *ngIf="isReadonlySetting('email.host')" matPrefix>lock</mat-icon>
           <mat-label>Host</mat-label>
-          <input #emailHostInput matInput formControlName="host" />
-          <mat-icon *ngIf="emailHostInput.disabled" matSuffix [matTooltip]="providedConfigurationMessage">lock</mat-icon>
+          <input matInput formControlName="host" />
         </mat-form-field>
 
-        <mat-form-field appearance="fill" class="settings-general__form__card__form-field">
+        <mat-form-field
+          [matTooltip]="providedConfigurationMessage"
+          [matTooltipDisabled]="!isReadonlySetting('email.port')"
+          appearance="fill"
+          class="settings-general__form__card__form-field"
+        >
+          <mat-icon *ngIf="isReadonlySetting('email.port')" matPrefix>lock</mat-icon>
           <mat-label>Port</mat-label>
-          <input #emailPortInput matInput formControlName="port" type="number" min="0" />
-          <mat-icon *ngIf="emailPortInput.disabled" matSuffix [matTooltip]="providedConfigurationMessage">lock</mat-icon>
+          <input matInput formControlName="port" type="number" min="0" />
         </mat-form-field>
 
-        <mat-form-field appearance="fill" class="settings-general__form__card__form-field">
+        <mat-form-field
+          [matTooltip]="providedConfigurationMessage"
+          [matTooltipDisabled]="!isReadonlySetting('email.username')"
+          appearance="fill"
+          class="settings-general__form__card__form-field"
+        >
+          <mat-icon *ngIf="isReadonlySetting('email.username')" matPrefix>lock</mat-icon>
           <mat-label>Username</mat-label>
-          <input #emailUsernameInput matInput formControlName="username" />
-          <mat-icon *ngIf="emailUsernameInput.disabled" matSuffix [matTooltip]="providedConfigurationMessage">lock</mat-icon>
+          <input matInput formControlName="username" />
         </mat-form-field>
 
-        <mat-form-field appearance="fill" class="settings-general__form__card__form-field">
+        <mat-form-field
+          [matTooltip]="providedConfigurationMessage"
+          [matTooltipDisabled]="!isReadonlySetting('email.password')"
+          appearance="fill"
+          class="settings-general__form__card__form-field"
+        >
+          <mat-icon *ngIf="isReadonlySetting('email.password')" matPrefix>lock</mat-icon>
           <mat-label>Password</mat-label>
-          <input #emailPasswordInput matInput formControlName="password" type="password" />
-          <mat-icon *ngIf="emailPasswordInput.disabled" matSuffix [matTooltip]="providedConfigurationMessage">lock</mat-icon>
+          <input matInput formControlName="password" type="password" />
         </mat-form-field>
 
-        <mat-form-field appearance="fill" class="settings-general__form__card__form-field">
+        <mat-form-field
+          [matTooltip]="providedConfigurationMessage"
+          [matTooltipDisabled]="!isReadonlySetting('email.protocol')"
+          appearance="fill"
+          class="settings-general__form__card__form-field"
+        >
+          <mat-icon *ngIf="isReadonlySetting('email.protocol')" matPrefix>lock</mat-icon>
           <mat-label>Protocol</mat-label>
-          <input #emailProtocolInput matInput formControlName="protocol" />
-          <mat-icon *ngIf="emailProtocolInput.disabled" matSuffix [matTooltip]="providedConfigurationMessage">lock</mat-icon>
+          <input matInput formControlName="protocol" />
         </mat-form-field>
 
-        <mat-form-field appearance="fill" class="settings-general__form__card__form-field">
+        <mat-form-field
+          [matTooltip]="providedConfigurationMessage"
+          [matTooltipDisabled]="!isReadonlySetting('email.subject')"
+          appearance="fill"
+          class="settings-general__form__card__form-field"
+        >
+          <mat-icon *ngIf="isReadonlySetting('email.subject')" matPrefix>lock</mat-icon>
           <mat-label>Subject</mat-label>
-          <input #emailSubjectInput matInput formControlName="subject" />
-          <mat-icon *ngIf="emailSubjectInput.disabled" matSuffix [matTooltip]="providedConfigurationMessage">lock</mat-icon>
+          <input matInput formControlName="subject" />
         </mat-form-field>
 
-        <mat-form-field appearance="fill" class="settings-general__form__card__form-field">
+        <mat-form-field
+          [matTooltip]="providedConfigurationMessage"
+          [matTooltipDisabled]="!isReadonlySetting('email.from')"
+          appearance="fill"
+          class="settings-general__form__card__form-field"
+        >
+          <mat-icon *ngIf="isReadonlySetting('email.from')" matPrefix>lock</mat-icon>
           <mat-label>From</mat-label>
-          <input #emailFromInput matInput formControlName="from" type="email" />
-          <mat-icon *ngIf="emailFromInput.disabled" matSuffix [matTooltip]="providedConfigurationMessage">lock</mat-icon>
+          <input matInput formControlName="from" type="email" />
         </mat-form-field>
 
         <mat-divider [inset]="true"></mat-divider>
@@ -347,10 +432,15 @@
             >
           </section>
 
-          <mat-form-field appearance="fill" class="settings-general__form__card__form-field">
+          <mat-form-field
+            [matTooltip]="providedConfigurationMessage"
+            [matTooltipDisabled]="!isReadonlySetting('email.sslTrust')"
+            appearance="fill"
+            class="settings-general__form__card__form-field"
+          >
+            <mat-icon *ngIf="isReadonlySetting('email.sslTrust')" matPrefix>lock</mat-icon>
             <mat-label>SSL Trust</mat-label>
             <input #emailPropertiesSslTrustInput matInput formControlName="sslTrust" />
-            <mat-icon *ngIf="emailPropertiesSslTrustInput.disabled" matSuffix [matTooltip]="providedConfigurationMessage">lock</mat-icon>
           </mat-form-field>
         </ng-container>
       </mat-card-content>

--- a/src/organization/configuration/console/org-settings-general.component.html
+++ b/src/organization/configuration/console/org-settings-general.component.html
@@ -39,44 +39,39 @@
           <mat-icon *ngIf="managementUrlInput.disabled" matSuffix [matTooltip]="providedConfigurationMessage">lock</mat-icon>
         </mat-form-field>
 
-        <section class="settings-general__form__card__checkbox-section">
-          <ng-container formGroupName="support">
-            <mat-checkbox
-              #managementSupportCheckbox
+        <mat-divider></mat-divider>
+
+        <gio-form-slide-toggle appearance="fill" class="console-settings__card__form-field" formGroupName="support">
+          <gio-form-label>Activate Support</gio-form-label>
+          <mat-slide-toggle gioFormSlideToggle formControlName="enabled" aria-label="Activate Support" name="support"></mat-slide-toggle>
+        </gio-form-slide-toggle>
+
+        <mat-divider></mat-divider>
+
+        <gio-form-slide-toggle appearance="fill" class="console-settings__card__form-field" formGroupName="userCreation">
+          <gio-form-label>Allow User Registration</gio-form-label>
+          <mat-slide-toggle
+            #managementUserCreationSlideToggle
+            gioFormSlideToggle
+            formControlName="enabled"
+            aria-label="Allow user creation"
+            name="userCreation"
+          ></mat-slide-toggle>
+        </gio-form-slide-toggle>
+
+        <ng-container *ngIf="managementUserCreationSlideToggle.checked">
+          <mat-divider></mat-divider>
+
+          <gio-form-slide-toggle appearance="fill" class="console-settings__card__form-field" formGroupName="automaticValidation">
+            <gio-form-label>Enable automatic validation of registration requests</gio-form-label>
+            <mat-slide-toggle
+              gioFormSlideToggle
               formControlName="enabled"
-              aria-label="Support"
-              [matTooltip]="providedConfigurationMessage"
-              [matTooltipDisabled]="!managementSupportCheckbox.disabled"
-              >Activate Support</mat-checkbox
-            >
-          </ng-container>
-        </section>
-        <section class="settings-general__form__card__checkbox-section">
-          <ng-container formGroupName="userCreation">
-            <mat-checkbox
-              #managementUserCreationCheckbox
-              formControlName="enabled"
-              aria-label="Allow user creation"
-              [matTooltip]="providedConfigurationMessage"
-              [matTooltipDisabled]="!managementUserCreationCheckbox.disabled"
-              >Allow User Registration</mat-checkbox
-            >
-          </ng-container>
-          <ul>
-            <li>
-              <ng-container formGroupName="automaticValidation">
-                <mat-checkbox
-                  #managementAutomaticValidationCheckbox
-                  formControlName="enabled"
-                  aria-label="Enable auto validation of creation"
-                  [matTooltip]="providedConfigurationMessage"
-                  [matTooltipDisabled]="!managementAutomaticValidationCheckbox.disabled"
-                  >Enable automatic validation of registration requests</mat-checkbox
-                >
-              </ng-container>
-            </li>
-          </ul>
-        </section>
+              aria-label="Enable auto validation of creation"
+              name="automaticValidation"
+            ></mat-slide-toggle>
+          </gio-form-slide-toggle>
+        </ng-container>
       </mat-card-content>
     </mat-card>
 

--- a/src/organization/configuration/console/org-settings-general.component.html
+++ b/src/organization/configuration/console/org-settings-general.component.html
@@ -372,158 +372,170 @@
             >lock</mat-icon
           >
           <gio-form-label>Enable Emailing</gio-form-label>
-          <mat-slide-toggle gioFormSlideToggle formControlName="enabled" aria-label="Email enabled" name="emailEnabled"></mat-slide-toggle>
+          <mat-slide-toggle
+            #emailEnabledSlideToggle
+            gioFormSlideToggle
+            formControlName="enabled"
+            aria-label="Email enabled"
+            name="emailEnabled"
+          ></mat-slide-toggle>
         </gio-form-slide-toggle>
 
-        <mat-divider></mat-divider>
-
-        <mat-form-field
-          [matTooltip]="providedConfigurationMessage"
-          [matTooltipDisabled]="!isReadonlySetting('email.host')"
-          appearance="fill"
-          class="settings-general__form__card__form-field margin-top"
-        >
-          <mat-icon *ngIf="isReadonlySetting('email.host')" class="settings-general__form__card__form-field__icon" matPrefix>lock</mat-icon>
-          <mat-label>Host</mat-label>
-          <input matInput formControlName="host" />
-        </mat-form-field>
-
-        <mat-form-field
-          [matTooltip]="providedConfigurationMessage"
-          [matTooltipDisabled]="!isReadonlySetting('email.port')"
-          appearance="fill"
-          class="settings-general__form__card__form-field"
-        >
-          <mat-icon *ngIf="isReadonlySetting('email.port')" class="settings-general__form__card__form-field__icon" matPrefix>lock</mat-icon>
-          <mat-label>Port</mat-label>
-          <input matInput formControlName="port" type="number" min="0" />
-        </mat-form-field>
-
-        <mat-form-field
-          [matTooltip]="providedConfigurationMessage"
-          [matTooltipDisabled]="!isReadonlySetting('email.username')"
-          appearance="fill"
-          class="settings-general__form__card__form-field"
-        >
-          <mat-icon *ngIf="isReadonlySetting('email.username')" class="settings-general__form__card__form-field__icon" matPrefix
-            >lock</mat-icon
-          >
-          <mat-label>Username</mat-label>
-          <input matInput formControlName="username" />
-        </mat-form-field>
-
-        <mat-form-field
-          [matTooltip]="providedConfigurationMessage"
-          [matTooltipDisabled]="!isReadonlySetting('email.password')"
-          appearance="fill"
-          class="settings-general__form__card__form-field"
-        >
-          <mat-icon *ngIf="isReadonlySetting('email.password')" class="settings-general__form__card__form-field__icon" matPrefix
-            >lock</mat-icon
-          >
-          <mat-label>Password</mat-label>
-          <input matInput formControlName="password" type="password" />
-        </mat-form-field>
-
-        <mat-form-field
-          [matTooltip]="providedConfigurationMessage"
-          [matTooltipDisabled]="!isReadonlySetting('email.protocol')"
-          appearance="fill"
-          class="settings-general__form__card__form-field"
-        >
-          <mat-icon *ngIf="isReadonlySetting('email.protocol')" class="settings-general__form__card__form-field__icon" matPrefix
-            >lock</mat-icon
-          >
-          <mat-label>Protocol</mat-label>
-          <input matInput formControlName="protocol" />
-        </mat-form-field>
-
-        <mat-form-field
-          [matTooltip]="providedConfigurationMessage"
-          [matTooltipDisabled]="!isReadonlySetting('email.subject')"
-          appearance="fill"
-          class="settings-general__form__card__form-field"
-        >
-          <mat-icon *ngIf="isReadonlySetting('email.subject')" class="settings-general__form__card__form-field__icon" matPrefix
-            >lock</mat-icon
-          >
-          <mat-label>Subject</mat-label>
-          <input matInput formControlName="subject" />
-        </mat-form-field>
-
-        <mat-form-field
-          [matTooltip]="providedConfigurationMessage"
-          [matTooltipDisabled]="!isReadonlySetting('email.from')"
-          appearance="fill"
-          class="settings-general__form__card__form-field"
-        >
-          <mat-icon *ngIf="isReadonlySetting('email.from')" class="settings-general__form__card__form-field__icon" matPrefix>lock</mat-icon>
-          <mat-label>From</mat-label>
-          <input matInput formControlName="from" type="email" />
-        </mat-form-field>
-
-        <mat-divider></mat-divider>
-
-        <h3 class="settings-general__form__card__h3">Mail properties</h3>
-        <ng-container formGroupName="properties">
-          <gio-form-slide-toggle
-            [matTooltip]="providedConfigurationMessage"
-            [matTooltipDisabled]="!isReadonlySetting('email.properties.auth')"
-            appearance="fill"
-            class="settings-general__form__card__form-field"
-          >
-            <mat-icon
-              *ngIf="isReadonlySetting('email.properties.auth')"
-              class="settings-general__form__card__form-field__icon"
-              gioFormPrefix
-              >lock</mat-icon
-            >
-            <gio-form-label>Enable Auth</gio-form-label>
-            <mat-slide-toggle
-              gioFormSlideToggle
-              formControlName="auth"
-              aria-label="Alerting enabled"
-              name="emailPropertiesAuth"
-            ></mat-slide-toggle>
-          </gio-form-slide-toggle>
-
-          <mat-divider></mat-divider>
-
-          <gio-form-slide-toggle
-            [matTooltip]="providedConfigurationMessage"
-            [matTooltipDisabled]="!isReadonlySetting('email.properties.startTlsEnable')"
-            appearance="fill"
-            class="settings-general__form__card__form-field"
-          >
-            <mat-icon
-              *ngIf="isReadonlySetting('email.properties.startTlsEnable')"
-              class="settings-general__form__card__form-field__icon"
-              gioFormPrefix
-              >lock</mat-icon
-            >
-            <gio-form-label>Enable Start TLS</gio-form-label>
-            <mat-slide-toggle
-              gioFormSlideToggle
-              formControlName="startTlsEnable"
-              aria-label="Start TLS enabled"
-              name="emailPropertiesStartTlsEnable"
-            ></mat-slide-toggle>
-          </gio-form-slide-toggle>
-
+        <ng-container *ngIf="emailEnabledSlideToggle.checked">
           <mat-divider></mat-divider>
 
           <mat-form-field
             [matTooltip]="providedConfigurationMessage"
-            [matTooltipDisabled]="!isReadonlySetting('email.sslTrust')"
+            [matTooltipDisabled]="!isReadonlySetting('email.host')"
             appearance="fill"
             class="settings-general__form__card__form-field margin-top"
           >
-            <mat-icon *ngIf="isReadonlySetting('email.sslTrust')" class="settings-general__form__card__form-field__icon" matPrefix
+            <mat-icon *ngIf="isReadonlySetting('email.host')" class="settings-general__form__card__form-field__icon" matPrefix
               >lock</mat-icon
             >
-            <mat-label>SSL Trust</mat-label>
-            <input #emailPropertiesSslTrustInput matInput formControlName="sslTrust" />
+            <mat-label>Host</mat-label>
+            <input matInput formControlName="host" />
           </mat-form-field>
+
+          <mat-form-field
+            [matTooltip]="providedConfigurationMessage"
+            [matTooltipDisabled]="!isReadonlySetting('email.port')"
+            appearance="fill"
+            class="settings-general__form__card__form-field"
+          >
+            <mat-icon *ngIf="isReadonlySetting('email.port')" class="settings-general__form__card__form-field__icon" matPrefix
+              >lock</mat-icon
+            >
+            <mat-label>Port</mat-label>
+            <input matInput formControlName="port" type="number" min="0" />
+          </mat-form-field>
+
+          <mat-form-field
+            [matTooltip]="providedConfigurationMessage"
+            [matTooltipDisabled]="!isReadonlySetting('email.username')"
+            appearance="fill"
+            class="settings-general__form__card__form-field"
+          >
+            <mat-icon *ngIf="isReadonlySetting('email.username')" class="settings-general__form__card__form-field__icon" matPrefix
+              >lock</mat-icon
+            >
+            <mat-label>Username</mat-label>
+            <input matInput formControlName="username" />
+          </mat-form-field>
+
+          <mat-form-field
+            [matTooltip]="providedConfigurationMessage"
+            [matTooltipDisabled]="!isReadonlySetting('email.password')"
+            appearance="fill"
+            class="settings-general__form__card__form-field"
+          >
+            <mat-icon *ngIf="isReadonlySetting('email.password')" class="settings-general__form__card__form-field__icon" matPrefix
+              >lock</mat-icon
+            >
+            <mat-label>Password</mat-label>
+            <input matInput formControlName="password" type="password" />
+          </mat-form-field>
+
+          <mat-form-field
+            [matTooltip]="providedConfigurationMessage"
+            [matTooltipDisabled]="!isReadonlySetting('email.protocol')"
+            appearance="fill"
+            class="settings-general__form__card__form-field"
+          >
+            <mat-icon *ngIf="isReadonlySetting('email.protocol')" class="settings-general__form__card__form-field__icon" matPrefix
+              >lock</mat-icon
+            >
+            <mat-label>Protocol</mat-label>
+            <input matInput formControlName="protocol" />
+          </mat-form-field>
+
+          <mat-form-field
+            [matTooltip]="providedConfigurationMessage"
+            [matTooltipDisabled]="!isReadonlySetting('email.subject')"
+            appearance="fill"
+            class="settings-general__form__card__form-field"
+          >
+            <mat-icon *ngIf="isReadonlySetting('email.subject')" class="settings-general__form__card__form-field__icon" matPrefix
+              >lock</mat-icon
+            >
+            <mat-label>Subject</mat-label>
+            <input matInput formControlName="subject" />
+          </mat-form-field>
+
+          <mat-form-field
+            [matTooltip]="providedConfigurationMessage"
+            [matTooltipDisabled]="!isReadonlySetting('email.from')"
+            appearance="fill"
+            class="settings-general__form__card__form-field"
+          >
+            <mat-icon *ngIf="isReadonlySetting('email.from')" class="settings-general__form__card__form-field__icon" matPrefix
+              >lock</mat-icon
+            >
+            <mat-label>From</mat-label>
+            <input matInput formControlName="from" type="email" />
+          </mat-form-field>
+
+          <h3 class="settings-general__form__card__h3">Mail properties</h3>
+          <ng-container formGroupName="properties">
+            <gio-form-slide-toggle
+              [matTooltip]="providedConfigurationMessage"
+              [matTooltipDisabled]="!isReadonlySetting('email.properties.auth')"
+              appearance="fill"
+              class="settings-general__form__card__form-field"
+            >
+              <mat-icon
+                *ngIf="isReadonlySetting('email.properties.auth')"
+                class="settings-general__form__card__form-field__icon"
+                gioFormPrefix
+                >lock</mat-icon
+              >
+              <gio-form-label>Enable Auth</gio-form-label>
+              <mat-slide-toggle
+                gioFormSlideToggle
+                formControlName="auth"
+                aria-label="Alerting enabled"
+                name="emailPropertiesAuth"
+              ></mat-slide-toggle>
+            </gio-form-slide-toggle>
+
+            <mat-divider></mat-divider>
+
+            <gio-form-slide-toggle
+              [matTooltip]="providedConfigurationMessage"
+              [matTooltipDisabled]="!isReadonlySetting('email.properties.startTlsEnable')"
+              appearance="fill"
+              class="settings-general__form__card__form-field"
+            >
+              <mat-icon
+                *ngIf="isReadonlySetting('email.properties.startTlsEnable')"
+                class="settings-general__form__card__form-field__icon"
+                gioFormPrefix
+                >lock</mat-icon
+              >
+              <gio-form-label>Enable Start TLS</gio-form-label>
+              <mat-slide-toggle
+                gioFormSlideToggle
+                formControlName="startTlsEnable"
+                aria-label="Start TLS enabled"
+                name="emailPropertiesStartTlsEnable"
+              ></mat-slide-toggle>
+            </gio-form-slide-toggle>
+
+            <mat-divider></mat-divider>
+
+            <mat-form-field
+              [matTooltip]="providedConfigurationMessage"
+              [matTooltipDisabled]="!isReadonlySetting('email.sslTrust')"
+              appearance="fill"
+              class="settings-general__form__card__form-field margin-top"
+            >
+              <mat-icon *ngIf="isReadonlySetting('email.sslTrust')" class="settings-general__form__card__form-field__icon" matPrefix
+                >lock</mat-icon
+              >
+              <mat-label>SSL Trust</mat-label>
+              <input #emailPropertiesSslTrustInput matInput formControlName="sslTrust" />
+            </mat-form-field>
+          </ng-container>
         </ng-container>
       </mat-card-content>
     </mat-card>

--- a/src/organization/configuration/console/org-settings-general.component.scss
+++ b/src/organization/configuration/console/org-settings-general.component.scss
@@ -1,4 +1,10 @@
+@use 'sass:map';
+@use 'node_modules/@angular/material' as mat;
+
 @import '../../../scss/gio-layout';
+@import '../../../scss/gio-material-theme';
+
+$foreground: map.get($gio-theme, foreground);
 
 :host {
   @include gio-responsive-margin-container;
@@ -20,6 +26,10 @@
 
       &__form-field {
         width: 100%;
+
+        &__icon {
+          color: mat.get-color-from-palette($foreground, disabled);
+        }
       }
 
       &__checkbox-section {

--- a/src/organization/configuration/console/org-settings-general.component.scss
+++ b/src/organization/configuration/console/org-settings-general.component.scss
@@ -30,13 +30,14 @@ $foreground: map.get($gio-theme, foreground);
         &__icon {
           color: mat.get-color-from-palette($foreground, disabled);
         }
+
+        &.margin-top {
+          margin-top: 16px;
+        }
       }
 
-      &__checkbox-section {
-        ul {
-          list-style-type: none;
-          margin-top: 4px;
-        }
+      &__h3 {
+        margin-top: 16px;
       }
     }
 

--- a/src/organization/configuration/console/org-settings-general.component.spec.ts
+++ b/src/organization/configuration/console/org-settings-general.component.spec.ts
@@ -19,7 +19,6 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatInputHarness } from '@angular/material/input/testing';
 import { MatFormFieldHarness } from '@angular/material/form-field/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
-import { MatCheckboxHarness } from '@angular/material/checkbox/testing';
 import { MatChipInputHarness, MatChipListHarness } from '@angular/material/chips/testing';
 import { MatSelectHarness } from '@angular/material/select/testing';
 import { MatAutocompleteHarness } from '@angular/material/autocomplete/testing';
@@ -448,6 +447,9 @@ describe('ConsoleSettingsComponent', () => {
   describe('email', () => {
     it('should disable field when setting is readonly', async () => {
       expectConsoleSettingsGetRequest({
+        email: {
+          enabled: true,
+        },
         metadata: {
           readonly: [
             'email.enabled',
@@ -547,22 +549,29 @@ describe('ConsoleSettingsComponent', () => {
       const emailEnabledEnableSlideToggle = await loader.getHarness(MatSlideToggleHarness.with({ name: 'emailEnabled' }));
       await emailEnabledEnableSlideToggle.uncheck();
 
-      // expect all email settings to be disabled
+      // expect all email settings to be not visible
       await Promise.all(
         ['Host', 'Port', 'Username', 'Password', 'Protocol', 'Subject', 'From', 'SSL Trust'].map(async (floatingLabelText) => {
-          const emailFormField = await loader.getHarness(MatFormFieldHarness.with({ floatingLabelText }));
+          const isEmailFormFieldVisible = await loader
+            .getHarness(MatFormFieldHarness.with({ floatingLabelText }))
+            .then(() => true)
+            .catch(() => false);
 
-          expect(await emailFormField.isDisabled()).toEqual(true);
+          expect(isEmailFormFieldVisible).toEqual(false);
         }),
       );
 
-      const propertiesAuthSlideToggle = await loader.getHarness(MatSlideToggleHarness.with({ name: 'emailPropertiesAuth' }));
-      expect(await propertiesAuthSlideToggle.isDisabled()).toEqual(true);
+      const isPropertiesAuthSlideToggleVisible = await loader
+        .getHarness(MatSlideToggleHarness.with({ name: 'emailPropertiesAuth' }))
+        .then(() => true)
+        .catch(() => false);
+      expect(await isPropertiesAuthSlideToggleVisible).toEqual(false);
 
-      const propertiesStartTlsEnableSlideToggle = await loader.getHarness(
-        MatSlideToggleHarness.with({ name: 'emailPropertiesStartTlsEnable' }),
-      );
-      expect(await propertiesStartTlsEnableSlideToggle.isDisabled()).toEqual(true);
+      const isPropertiesStartTlsEnableSlideToggleVisible = await loader
+        .getHarness(MatSlideToggleHarness.with({ name: 'emailPropertiesStartTlsEnable' }))
+        .then(() => true)
+        .catch(() => false);
+      expect(await isPropertiesStartTlsEnableSlideToggleVisible).toEqual(false);
 
       await emailEnabledEnableSlideToggle.check();
 
@@ -582,8 +591,12 @@ describe('ConsoleSettingsComponent', () => {
         }),
       );
 
+      const propertiesAuthSlideToggle = await loader.getHarness(MatSlideToggleHarness.with({ name: 'emailPropertiesAuth' }));
       expect(await propertiesAuthSlideToggle.isDisabled()).toEqual(true);
 
+      const propertiesStartTlsEnableSlideToggle = await loader.getHarness(
+        MatSlideToggleHarness.with({ name: 'emailPropertiesStartTlsEnable' }),
+      );
       expect(await propertiesStartTlsEnableSlideToggle.isDisabled()).toEqual(false);
     });
   });

--- a/src/organization/configuration/console/org-settings-general.component.spec.ts
+++ b/src/organization/configuration/console/org-settings-general.component.spec.ts
@@ -27,6 +27,7 @@ import { MatDialogHarness } from '@angular/material/dialog/testing';
 import { HttpTestingController } from '@angular/common/http/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { InteractivityChecker } from '@angular/cdk/a11y';
+import { MatSlideToggleHarness } from '@angular/material/slide-toggle/testing';
 
 import { OrgSettingsGeneralComponent } from './org-settings-general.component';
 
@@ -85,8 +86,8 @@ describe('ConsoleSettingsComponent', () => {
       const titleFormField = await loader.getHarness(MatFormFieldHarness.with({ floatingLabelText: 'Title' }));
       expect(await titleFormField.isDisabled()).toEqual(true);
 
-      const activateSupportCheckbox = await loader.getHarness(MatCheckboxHarness.with({ label: 'Activate Support' }));
-      expect(await activateSupportCheckbox.isDisabled()).toEqual(false);
+      const activateSupportSlideToggle = await loader.getHarness(MatSlideToggleHarness.with({ name: 'support' }));
+      expect(await activateSupportSlideToggle.isDisabled()).toEqual(false);
     });
 
     it('should save management settings', async () => {
@@ -106,8 +107,8 @@ describe('ConsoleSettingsComponent', () => {
       const titleInput = await titleFormField.getControl(MatInputHarness);
       await titleInput?.setValue('New Title');
 
-      const activateSupportCheckbox = await loader.getHarness(MatCheckboxHarness.with({ label: 'Activate Support' }));
-      await activateSupportCheckbox.check();
+      const activateSupportSlideToggle = await loader.getHarness(MatSlideToggleHarness.with({ name: 'support' }));
+      await activateSupportSlideToggle.check();
 
       const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
       await saveButton.click();
@@ -141,12 +142,14 @@ describe('ConsoleSettingsComponent', () => {
       const titleInput = await titleFormField.getControl(MatInputHarness);
       await titleInput?.setValue('New Title');
 
-      const userCreationCheckbox = await loader.getHarness(MatCheckboxHarness.with({ label: 'Allow User Registration' }));
-      const automaticValidationCheckbox = await loader.getHarness(MatCheckboxHarness.with({ label: /^Enable automatic validation/ }));
+      const userCreationSlideToggle = await loader.getHarness(MatSlideToggleHarness.with({ name: 'userCreation' }));
+      const automaticValidationSlideToggle = await loader.getHarness(MatSlideToggleHarness.with({ name: 'automaticValidation' }));
 
-      expect(await automaticValidationCheckbox.isDisabled()).toEqual(false);
-      await userCreationCheckbox.uncheck();
-      expect(await automaticValidationCheckbox.isDisabled()).toEqual(true);
+      expect(await automaticValidationSlideToggle.isDisabled()).toEqual(false);
+      await userCreationSlideToggle.toggle();
+
+      // expect automaticValidation SlideToggle not to be visible
+      expect(await loader.getAllHarnesses(MatSlideToggleHarness.with({ name: 'automaticValidation' }))).toEqual([]);
 
       const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
       await saveButton.click();

--- a/src/organization/configuration/console/org-settings-general.component.spec.ts
+++ b/src/organization/configuration/console/org-settings-general.component.spec.ts
@@ -279,8 +279,8 @@ describe('ConsoleSettingsComponent', () => {
         },
       });
 
-      const enableAlertingCheckbox = await loader.getHarness(MatCheckboxHarness.with({ label: 'Enable Alerting' }));
-      expect(await enableAlertingCheckbox.isDisabled()).toEqual(true);
+      const enableAlertingSlideToggle = await loader.getHarness(MatSlideToggleHarness.with({ name: 'alert' }));
+      expect(await enableAlertingSlideToggle.isDisabled()).toEqual(true);
     });
 
     it('should save alert settings', async () => {
@@ -290,8 +290,8 @@ describe('ConsoleSettingsComponent', () => {
         },
       });
 
-      const enableAlertingCheckbox = await loader.getHarness(MatCheckboxHarness.with({ label: 'Enable Alerting' }));
-      await enableAlertingCheckbox.check();
+      const enableAlertingSlideToggle = await loader.getHarness(MatSlideToggleHarness.with({ name: 'alert' }));
+      await enableAlertingSlideToggle.check();
 
       const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
       await saveButton.click();
@@ -465,8 +465,8 @@ describe('ConsoleSettingsComponent', () => {
         },
       });
 
-      const emailEnabledEnableCheckbox = await loader.getHarness(MatCheckboxHarness.with({ label: 'Enable Emailing' }));
-      expect(await emailEnabledEnableCheckbox.isDisabled()).toEqual(true);
+      const emailEnabledEnableSlideToggle = await loader.getHarness(MatSlideToggleHarness.with({ name: 'emailEnabled' }));
+      expect(await emailEnabledEnableSlideToggle.isDisabled()).toEqual(true);
 
       await Promise.all(
         ['Host', 'Port', 'Username', 'Password', 'Protocol', 'Subject', 'From', 'SSL Trust'].map(async (floatingLabelText) => {
@@ -476,11 +476,13 @@ describe('ConsoleSettingsComponent', () => {
         }),
       );
 
-      const propertiesAuthCheckbox = await loader.getHarness(MatCheckboxHarness.with({ label: 'Enable Auth' }));
-      expect(await propertiesAuthCheckbox.isDisabled()).toEqual(true);
+      const propertiesAuthSlideToggle = await loader.getHarness(MatSlideToggleHarness.with({ name: 'emailPropertiesAuth' }));
+      expect(await propertiesAuthSlideToggle.isDisabled()).toEqual(true);
 
-      const propertiesStartTlsEnableCheckbox = await loader.getHarness(MatCheckboxHarness.with({ label: 'Enable Start TLS' }));
-      expect(await propertiesStartTlsEnableCheckbox.isDisabled()).toEqual(true);
+      const propertiesStartTlsEnableSlideToggle = await loader.getHarness(
+        MatSlideToggleHarness.with({ name: 'emailPropertiesStartTlsEnable' }),
+      );
+      expect(await propertiesStartTlsEnableSlideToggle.isDisabled()).toEqual(true);
     });
 
     it('should save email settings', async () => {
@@ -506,11 +508,13 @@ describe('ConsoleSettingsComponent', () => {
         }),
       );
 
-      const propertiesAuthCheckbox = await loader.getHarness(MatCheckboxHarness.with({ label: 'Enable Auth' }));
-      await propertiesAuthCheckbox.uncheck();
+      const propertiesAuthSlideToggle = await loader.getHarness(MatSlideToggleHarness.with({ name: 'emailPropertiesAuth' }));
+      await propertiesAuthSlideToggle.uncheck();
 
-      const propertiesStartTlsEnableCheckbox = await loader.getHarness(MatCheckboxHarness.with({ label: 'Enable Start TLS' }));
-      await propertiesStartTlsEnableCheckbox.check();
+      const propertiesStartTlsEnableSlideToggle = await loader.getHarness(
+        MatSlideToggleHarness.with({ name: 'emailPropertiesStartTlsEnable' }),
+      );
+      await propertiesStartTlsEnableSlideToggle.check();
 
       const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
       await saveButton.click();
@@ -540,8 +544,8 @@ describe('ConsoleSettingsComponent', () => {
         },
       });
 
-      const emailEnabledEnableCheckbox = await loader.getHarness(MatCheckboxHarness.with({ label: 'Enable Emailing' }));
-      await emailEnabledEnableCheckbox.uncheck();
+      const emailEnabledEnableSlideToggle = await loader.getHarness(MatSlideToggleHarness.with({ name: 'emailEnabled' }));
+      await emailEnabledEnableSlideToggle.uncheck();
 
       // expect all email settings to be disabled
       await Promise.all(
@@ -552,13 +556,15 @@ describe('ConsoleSettingsComponent', () => {
         }),
       );
 
-      const propertiesAuthCheckbox = await loader.getHarness(MatCheckboxHarness.with({ label: 'Enable Auth' }));
-      expect(await propertiesAuthCheckbox.isDisabled()).toEqual(true);
+      const propertiesAuthSlideToggle = await loader.getHarness(MatSlideToggleHarness.with({ name: 'emailPropertiesAuth' }));
+      expect(await propertiesAuthSlideToggle.isDisabled()).toEqual(true);
 
-      const propertiesStartTlsEnableCheckbox = await loader.getHarness(MatCheckboxHarness.with({ label: 'Enable Start TLS' }));
-      expect(await propertiesStartTlsEnableCheckbox.isDisabled()).toEqual(true);
+      const propertiesStartTlsEnableSlideToggle = await loader.getHarness(
+        MatSlideToggleHarness.with({ name: 'emailPropertiesStartTlsEnable' }),
+      );
+      expect(await propertiesStartTlsEnableSlideToggle.isDisabled()).toEqual(true);
 
-      await emailEnabledEnableCheckbox.check();
+      await emailEnabledEnableSlideToggle.check();
 
       // Expect all email settings to be enabled except for read-only settings
       await Promise.all(
@@ -576,9 +582,9 @@ describe('ConsoleSettingsComponent', () => {
         }),
       );
 
-      expect(await propertiesAuthCheckbox.isDisabled()).toEqual(true);
+      expect(await propertiesAuthSlideToggle.isDisabled()).toEqual(true);
 
-      expect(await propertiesStartTlsEnableCheckbox.isDisabled()).toEqual(false);
+      expect(await propertiesStartTlsEnableSlideToggle.isDisabled()).toEqual(false);
     });
   });
 

--- a/src/organization/configuration/console/org-settings-general.component.spec.ts
+++ b/src/organization/configuration/console/org-settings-general.component.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { HarnessLoader } from '@angular/cdk/testing';
+import { HarnessLoader, TestKey } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatInputHarness } from '@angular/material/input/testing';
 import { MatFormFieldHarness } from '@angular/material/form-field/testing';
@@ -373,7 +373,7 @@ describe('ConsoleSettingsComponent', () => {
       const allowHeadersChipListInput = await allowHeadersChipList.getInput();
       // Add new custom header
       await allowHeadersChipListInput.setValue('x-ray');
-      await allowHeadersChipListInput.blur();
+      await allowHeadersChipListInput.sendSeparatorKey(TestKey.ENTER);
       // Remove x-foo header
       await (await allowHeadersChipList.getChips({ text: 'x-foo' }))[0].remove();
       // Check headers

--- a/src/organization/configuration/console/org-settings-general.component.ts
+++ b/src/organization/configuration/console/org-settings-general.component.ts
@@ -260,6 +260,10 @@ export class OrgSettingsGeneralComponent implements OnInit, OnDestroy {
       )
       .subscribe();
   }
+
+  isReadonlySetting(property: string): boolean {
+    return isReadonlySetting(this.settings, property);
+  }
 }
 
 const isReadonlySetting = (consoleSettings: ConsoleSettings, property: string): boolean => {

--- a/src/organization/configuration/organization-settings.module.ts
+++ b/src/organization/configuration/organization-settings.module.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { MatButtonModule } from '@angular/material/button';
@@ -32,7 +33,7 @@ import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatTableModule } from '@angular/material/table';
 import { MatBadgeModule } from '@angular/material/badge';
 import { MatPaginatorModule } from '@angular/material/paginator';
-import { CommonModule } from '@angular/common';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 
 import { OrgSettingsGeneralComponent } from './console/org-settings-general.component';
 import { OrgSettingsUsersComponent } from './users/org-settings-users.component';
@@ -41,6 +42,7 @@ import { OrgSettingsNewUserComponent } from './user/new/org-settings-new-user.co
 import { GioConfirmDialogModule } from '../../shared/components/confirm-dialog/confirm-dialog.module';
 import { GioAvatarModule } from '../../shared/components/gio-avatar/gio-avatar.module';
 import { GioTableOfContentsModule } from '../../shared/components/gio-table-of-contents/gio-table-of-contents.module';
+import { GioFormSlideToggleModule } from '../../shared/components/form-slide-toogle/gio-form-slide-toggle.module';
 
 @NgModule({
   imports: [
@@ -64,10 +66,13 @@ import { GioTableOfContentsModule } from '../../shared/components/gio-table-of-c
     MatTableModule,
     MatBadgeModule,
     MatPaginatorModule,
+    MatSlideToggleModule,
+    MatDividerModule,
 
     GioConfirmDialogModule,
     GioAvatarModule,
     GioTableOfContentsModule,
+    GioFormSlideToggleModule,
   ],
   declarations: [OrgSettingsGeneralComponent, OrgSettingsUsersComponent, OrgSettingsNewUserComponent],
   exports: [OrgSettingsGeneralComponent, OrgSettingsUsersComponent],

--- a/src/shared/components/form-slide-toogle/__snapshots__/gio-form-slide-toggle.component.spec.ts.snap
+++ b/src/shared/components/form-slide-toogle/__snapshots__/gio-form-slide-toggle.component.spec.ts.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`GioFormSlideToggleComponent should match snapshot 1`] = `
+GioFormSlideToggleComponent {
+  "disabled": false,
+}
+`;

--- a/src/shared/components/form-slide-toogle/gio-form-label.directive.ts
+++ b/src/shared/components/form-slide-toogle/gio-form-label.directive.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Directive } from '@angular/core';
+
+@Directive({
+  selector: 'gio-form-label',
+})
+export class GioFormLabelDirective {}
+
+@Directive({
+  selector: '[gioFormPrefix]',
+})
+export class GioFormPrefixDirective {}
+
+@Directive({
+  selector: '[gioFormSlideToggle]',
+})
+export class GioFormSlideToggleDirective {}

--- a/src/shared/components/form-slide-toogle/gio-form-slide-toggle.component.html
+++ b/src/shared/components/form-slide-toogle/gio-form-slide-toggle.component.html
@@ -1,0 +1,35 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="form-slide-toggle" [class.appearance-standard]="appearance === 'standard'" [class.appearance-fill]="appearance === 'fill'">
+  <div class="form-slide-toggle__icon">
+    <ng-content select="[gioFormPrefix]"></ng-content>
+  </div>
+  <div class="form-slide-toggle__field">
+    <div class="form-slide-toggle__field__text" [class.disabled]="disabled">
+      <span class="form-slide-toggle__field__text__label-1">
+        <ng-content select="gio-form-label"></ng-content>
+      </span>
+      <span class="form-slide-toggle__field__text__label-2">
+        <ng-content></ng-content>
+      </span>
+    </div>
+    <div class="form-slide-toggle__field__mat-slide-toggle">
+      <ng-content select="[gioFormSlideToggle]"></ng-content>
+    </div>
+  </div>
+</div>

--- a/src/shared/components/form-slide-toogle/gio-form-slide-toggle.component.scss
+++ b/src/shared/components/form-slide-toogle/gio-form-slide-toggle.component.scss
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@use 'sass:map';
+@use 'node_modules/@angular/material' as mat;
+
+@import '../../../scss/gio-material-theme';
+
+$typography: map.get($gio-theme, typography);
+$foreground: map.get($gio-theme, foreground);
+
+:host {
+  display: inline-block;
+}
+
+.form-slide-toggle {
+  display: flex;
+  align-items: center;
+  height: 60px;
+  //   width: 100%;
+
+  &.appearance-fill {
+    padding: 0 0.75em 0 0.75em;
+  }
+
+  &__field {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: flex-start;
+    min-width: 180px;
+    flex: 1 1 auto;
+
+    &__text {
+      flex: 1 1 100%;
+      display: flex;
+      flex-direction: column;
+
+      &__label-1 {
+        @include mat.typography-level($typography, body-2);
+      }
+
+      &__label-2 {
+        @include mat.typography-level($typography, body-1);
+      }
+
+      &.disabled {
+        color: mat.get-color-from-palette($foreground, disabled-text);
+      }
+    }
+  }
+}

--- a/src/shared/components/form-slide-toogle/gio-form-slide-toggle.component.scss
+++ b/src/shared/components/form-slide-toogle/gio-form-slide-toggle.component.scss
@@ -63,3 +63,11 @@ $foreground: map.get($gio-theme, foreground);
     }
   }
 }
+
+// to change style in component provide by ng-content
+::ng-deep .form-slide-toggle__icon {
+  .mat-icon {
+    font-size: 150%;
+    line-height: 1.125;
+  }
+}

--- a/src/shared/components/form-slide-toogle/gio-form-slide-toggle.component.spec.ts
+++ b/src/shared/components/form-slide-toogle/gio-form-slide-toggle.component.spec.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { GioFormSlideToggleComponent } from './gio-form-slide-toggle.component';
+import { GioFormSlideToggleModule } from './gio-form-slide-toggle.module';
+
+describe('GioFormSlideToggleComponent', () => {
+  let component: GioFormSlideToggleComponent;
+  let fixture: ComponentFixture<GioFormSlideToggleComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [GioFormSlideToggleModule],
+    });
+    fixture = TestBed.createComponent(GioFormSlideToggleComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should match snapshot', () => {
+    fixture.detectChanges();
+    expect(component).toMatchSnapshot();
+  });
+});

--- a/src/shared/components/form-slide-toogle/gio-form-slide-toggle.component.ts
+++ b/src/shared/components/form-slide-toogle/gio-form-slide-toggle.component.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, ContentChild, Input } from '@angular/core';
+import { MatSlideToggle } from '@angular/material/slide-toggle';
+
+@Component({
+  selector: 'gio-form-slide-toggle',
+  template: require('./gio-form-slide-toggle.component.html'),
+  styles: [require('./gio-form-slide-toggle.component.scss')],
+})
+export class GioFormSlideToggleComponent {
+  @Input() appearance: string;
+
+  @ContentChild(MatSlideToggle, { static: true }) set slideToggle(slideToggle: MatSlideToggle | null) {
+    if (slideToggle) {
+      this.disabled = slideToggle.disabled;
+    }
+  }
+
+  disabled = false;
+}

--- a/src/shared/components/form-slide-toogle/gio-form-slide-toggle.module.ts
+++ b/src/shared/components/form-slide-toogle/gio-form-slide-toggle.module.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+
+import { GioFormLabelDirective, GioFormPrefixDirective } from './gio-form-label.directive';
+import { GioFormSlideToggleComponent } from './gio-form-slide-toggle.component';
+
+@NgModule({
+  imports: [CommonModule],
+  declarations: [GioFormSlideToggleComponent, GioFormLabelDirective, GioFormPrefixDirective],
+  exports: [GioFormSlideToggleComponent, GioFormLabelDirective, GioFormPrefixDirective],
+  entryComponents: [GioFormSlideToggleComponent],
+})
+export class GioFormSlideToggleModule {}

--- a/src/shared/components/form-slide-toogle/gio-form-slide-toggle.stories.ts
+++ b/src/shared/components/form-slide-toogle/gio-form-slide-toggle.stories.ts
@@ -1,0 +1,213 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Meta, moduleMetadata, Story } from '@storybook/angular';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { MatIconModule } from '@angular/material/icon';
+
+import { GioFormSlideToggleComponent } from './gio-form-slide-toggle.component';
+import { GioFormSlideToggleModule } from './gio-form-slide-toggle.module';
+
+export default {
+  title: 'Shared / Form slide toggle',
+  component: GioFormSlideToggleComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [BrowserAnimationsModule, GioFormSlideToggleModule, MatSlideToggleModule, MatFormFieldModule, MatInputModule, MatIconModule],
+    }),
+  ],
+  render: () => ({}),
+} as Meta;
+
+export const OnlyToggle: Story = {
+  render: () => ({
+    template: '<gio-form-slide-toggle><mat-slide-toggle gioFormSlideToggle></mat-slide-toggle></gio-form-slide-toggle>',
+  }),
+};
+
+export const WithLabel1: Story = {
+  render: () => ({
+    template: `
+      <gio-form-slide-toggle>
+        <gio-form-label>Label 1</gio-form-label>
+        <mat-slide-toggle gioFormSlideToggle></mat-slide-toggle>
+      </gio-form-slide-toggle>
+    `,
+  }),
+};
+
+export const WithLabel2: Story = {
+  render: () => ({
+    template: `
+      <gio-form-slide-toggle>
+        Label 2 - Description
+        <mat-slide-toggle gioFormSlideToggle></mat-slide-toggle>
+      </gio-form-slide-toggle>
+    `,
+  }),
+};
+
+export const WithLabel1AndLabel2: Story = {
+  render: () => ({
+    template: `
+      <gio-form-slide-toggle>
+        <gio-form-label>Label 1</gio-form-label>
+        Label 2 - Description
+        <mat-slide-toggle gioFormSlideToggle></mat-slide-toggle>
+      </gio-form-slide-toggle>
+    `,
+  }),
+};
+
+export const SimilarToMatFormField: Story = {
+  render: ({ appearance }) => ({
+    template: `
+      <p>
+        <mat-form-field [appearance]="appearance">
+          <mat-label>Standard form field</mat-label>
+          <input matInput placeholder="Placeholder">
+          <mat-hint>Hint</mat-hint>
+        </mat-form-field>
+      </p>
+      <p>
+        <gio-form-slide-toggle [appearance]="appearance">
+          <gio-form-label>Label 1</gio-form-label>
+          Label 2 - Description
+          <mat-slide-toggle gioFormSlideToggle></mat-slide-toggle>
+        </gio-form-slide-toggle>
+      </p>
+    `,
+    props: { appearance },
+  }),
+  argTypes: {
+    appearance: {
+      options: ['standard', 'fill'],
+      control: { type: 'select' },
+    },
+  },
+  args: {
+    appearance: 'fill',
+  },
+};
+
+export const SimilarToMatFormFieldWithIcon: Story = {
+  render: ({ appearance }) => ({
+    template: `
+      <p>
+        <mat-form-field [appearance]="appearance">
+          <mat-icon matPrefix>lock</mat-icon>
+          <mat-label>Standard form field</mat-label>
+          <input matInput placeholder="Placeholder">
+          <mat-hint>Hint</mat-hint>
+        </mat-form-field>
+      </p>
+      <p>
+        <gio-form-slide-toggle [appearance]="appearance">
+          <mat-icon gioFormPrefix>lock</mat-icon>
+          <gio-form-label>Label 1</gio-form-label>
+          Label 2 - Description
+          <mat-slide-toggle gioFormSlideToggle></mat-slide-toggle>
+        </gio-form-slide-toggle>
+      </p>
+    `,
+    props: { appearance },
+  }),
+  argTypes: {
+    appearance: {
+      options: ['standard', 'fill'],
+      control: { type: 'select' },
+    },
+  },
+  args: {
+    appearance: 'standard',
+  },
+};
+
+export const SimilarToMatFormFieldDisabled: Story = {
+  render: ({ disabled, appearance }) => ({
+    template: `
+      <p>
+        <mat-form-field [appearance]="appearance">
+          <mat-icon matPrefix>lock</mat-icon>
+          <mat-label>Standard form field</mat-label>
+          <input [disabled]="disabled" matInput value="Value">
+          <mat-hint>Hint</mat-hint>
+        </mat-form-field>
+      </p>
+      <p>
+        <gio-form-slide-toggle [appearance]="appearance">
+          <mat-icon gioFormPrefix>lock</mat-icon>
+          <gio-form-label>Label 1</gio-form-label>
+          Label 2 - Description
+          <mat-slide-toggle gioFormSlideToggle [disabled]="disabled"></mat-slide-toggle>
+        </gio-form-slide-toggle>
+      </p>
+    `,
+    props: { disabled, appearance },
+  }),
+  argTypes: {
+    disabled: {
+      type: { name: 'boolean', required: false },
+    },
+    appearance: {
+      options: ['standard', 'fill'],
+      control: { type: 'select' },
+    },
+  },
+  args: {
+    disabled: true,
+    appearance: 'fill',
+  },
+};
+
+export const FullWidth: Story = {
+  render: ({ disabled, appearance }) => ({
+    template: `
+      <p>
+        <mat-form-field [appearance]="appearance" style="width:100%">
+          <mat-icon matPrefix>lock</mat-icon>
+          <mat-label>Standard form field</mat-label>
+          <input [disabled]="disabled" matInput value="Value">
+          <mat-hint>Hint</mat-hint>
+        </mat-form-field>
+      </p>
+      <p>
+        <gio-form-slide-toggle [appearance]="appearance" style="width:100%">
+          <mat-icon gioFormPrefix>lock</mat-icon>
+          <gio-form-label>Label 1</gio-form-label>
+          Label 2 - Description
+          <mat-slide-toggle gioFormSlideToggle [disabled]="disabled"></mat-slide-toggle>
+        </gio-form-slide-toggle>
+      </p>
+    `,
+    props: { disabled, appearance },
+  }),
+  argTypes: {
+    disabled: {
+      type: { name: 'boolean', required: false },
+    },
+    appearance: {
+      options: ['standard', 'fill'],
+      control: { type: 'select' },
+    },
+  },
+  args: {
+    disabled: false,
+    appearance: 'fill',
+  },
+};

--- a/src/shared/components/form-slide-toogle/gio-form-slide-toggle.stories.ts
+++ b/src/shared/components/form-slide-toogle/gio-form-slide-toggle.stories.ts
@@ -108,7 +108,7 @@ export const SimilarToMatFormField: Story = {
 export const SimilarToMatFormFieldWithIcon: Story = {
   render: ({ appearance }) => ({
     template: `
-      <p>
+      <p class="mat-body">
         <mat-form-field [appearance]="appearance">
           <mat-icon matPrefix>lock</mat-icon>
           <mat-label>Standard form field</mat-label>
@@ -116,7 +116,7 @@ export const SimilarToMatFormFieldWithIcon: Story = {
           <mat-hint>Hint</mat-hint>
         </mat-form-field>
       </p>
-      <p>
+      <p class="mat-body">
         <gio-form-slide-toggle [appearance]="appearance">
           <mat-icon gioFormPrefix>lock</mat-icon>
           <gio-form-label>Label 1</gio-form-label>


### PR DESCRIPTION
**Issue**
https://github.com/gravitee-io/issues/issues/6182

**Description**

Create new form-field for toggle similar to mat-form-field
Use it in settings general 
Improve settings general lock icon an tooltips

**Screenshots**
before: 
![image](https://user-images.githubusercontent.com/4974420/134178845-f463e69a-249a-4eef-9d1a-646bfd598bc0.png)

after:
![image](https://user-images.githubusercontent.com/4974420/134178217-37a2bdda-5eb3-4243-b656-246341e6e803.png)

before: 
![image](https://user-images.githubusercontent.com/4974420/134178763-19dc529c-3e00-4157-a54c-09671fa5029e.png)

after:
![image](https://user-images.githubusercontent.com/4974420/134178367-d6f8c3ac-62fc-4042-a18f-33b92e6e5b42.png)

**Additional context**

![image](https://user-images.githubusercontent.com/4974420/134178282-0b57f1e4-52e4-420f-8e2c-b4724e5800d1.png)
![image](https://user-images.githubusercontent.com/4974420/134178984-3ba96fd5-47de-4e6b-b692-28bdbd7bee87.png)

