### PR TITLE
Add missing env var in `weekly-purge-azure-registry` workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,7 +214,7 @@ jobs:
 
             gh pr comment --body "**Gravitee.io Automatic Deployment**
 
-            📚 View the storybook of this branch [here](${SB_URL}) 
+            📚 View the storybook of this branch [here](${SB_URL})
             "
 
   publish-images-azure-registry:
@@ -715,8 +715,8 @@ workflows:
                 - master
                 - /^[0-999].[0-999].x/
 
-  # Purge master azure registry
-  daily-purge-azure-registry:
+  # Purge master azure registry every monday
+  weekly-purge-azure-registry:
     triggers:
       - schedule:
           cron: "0 1 * * 1"
@@ -725,4 +725,16 @@ workflows:
               only:
                 - master
     jobs:
-      - purge-master-azure-registry
+      - purge-master-azure-registry:
+          context: cicd-orchestrator
+          pre-steps:
+            - secrethub/env-export:
+                secret-path: graviteeio/cicd/azure/application-id
+                var-name: AZURE_APPLICATION_ID
+            - secrethub/env-export:
+                secret-path: graviteeio/cicd/azure/tenant
+                var-name: AZURE_TENANT
+            - secrethub/env-export:
+                secret-path: graviteeio/cicd/azure/application-secret
+                var-name: AZURE_APPLICATION_SECRET
+


### PR DESCRIPTION
**Issue**

NA

**Description**

The `weekly-purge-azure-registry` workflow was calling `purge-master-azure-registry` without setting any environment variables, causing the job to throw, for example: https://app.circleci.com/pipelines/github/gravitee-io/gravitee-management-webui/2362/workflows/b04942e5-b025-44a1-8f3c-fdb24ac81d88/jobs/4452

I just added the needed env vars and updated the job name to match the corn expression