### PR TITLE
Create an Angular permission directive

### DIFF
--- a/src/ajs-upgraded-providers.ts
+++ b/src/ajs-upgraded-providers.ts
@@ -40,3 +40,14 @@ export const uiRouterStateParamsProvider = {
   useFactory: uiRouterStateParamsServiceFactory,
   deps: ['$injector'],
 };
+
+export const CurrentUserService = new InjectionToken('CurrentUserService');
+
+function currentUserServiceFactory(i: any) {
+  return i.get('UserService');
+}
+export const currentUserProvider = {
+  provide: CurrentUserService,
+  useFactory: currentUserServiceFactory,
+  deps: ['$injector'],
+};

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -20,7 +20,7 @@ import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { UpgradeModule } from '@angular/upgrade/static';
 
-import { uiRouterStateProvider, uiRouterStateParamsProvider } from './ajs-upgraded-providers';
+import { uiRouterStateProvider, uiRouterStateParamsProvider, currentUserProvider } from './ajs-upgraded-providers';
 import { OrganizationSettingsModule } from './organization/configuration/organization-settings.module';
 import { httpInterceptorProviders } from './shared/interceptors/http-interceptors';
 
@@ -38,7 +38,7 @@ import { httpInterceptorProviders } from './shared/interceptors/http-interceptor
     UpgradeModule,
     OrganizationSettingsModule,
   ],
-  providers: [httpInterceptorProviders, uiRouterStateProvider, uiRouterStateParamsProvider],
+  providers: [httpInterceptorProviders, uiRouterStateProvider, uiRouterStateParamsProvider, currentUserProvider],
 })
 export class AppModule {
   constructor(private upgrade: UpgradeModule) {}

--- a/src/entities/user/userDetails.ts
+++ b/src/entities/user/userDetails.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export interface UserDetails {
+  id: string;
+  email: string;
+  firstname: string;
+  lastname: string;
+  source: string;
+  sourceId: string;
+  isPrimaryOwner: boolean;
+  roles: any[];
+  groupsByEnvironment: Record<string, string[]>;
+  username: string;
+  picture: any[];
+  firstLogin: boolean;
+  displayNewsletterSubscription: boolean;
+  customFields: Record<string, any>;
+  created_at: number;
+  updatedAt: number;
+  lastConnectionAt: number;
+}

--- a/src/organization/configuration/organization-settings.module.ts
+++ b/src/organization/configuration/organization-settings.module.ts
@@ -43,6 +43,7 @@ import { GioConfirmDialogModule } from '../../shared/components/confirm-dialog/c
 import { GioAvatarModule } from '../../shared/components/gio-avatar/gio-avatar.module';
 import { GioTableOfContentsModule } from '../../shared/components/gio-table-of-contents/gio-table-of-contents.module';
 import { GioFormSlideToggleModule } from '../../shared/components/form-slide-toogle/gio-form-slide-toggle.module';
+import { GioPermissionModule } from '../../shared/components/gio-permission/gio-permission.module';
 
 @NgModule({
   imports: [
@@ -69,6 +70,7 @@ import { GioFormSlideToggleModule } from '../../shared/components/form-slide-too
     MatSlideToggleModule,
     MatDividerModule,
 
+    GioPermissionModule,
     GioConfirmDialogModule,
     GioAvatarModule,
     GioTableOfContentsModule,

--- a/src/organization/configuration/users/org-settings-users.component.html
+++ b/src/organization/configuration/users/org-settings-users.component.html
@@ -79,16 +79,18 @@
     <ng-container matColumnDef="actions">
       <th mat-header-cell *matHeaderCellDef id="actions" width="1%"></th>
       <td mat-cell *matCellDef="let element">
-        <button
-          *ngIf="!element.primary_owner"
-          (click)="onDeleteUserClick(element)"
-          mat-icon-button
-          color="primary"
-          aria-label="Button to delete user"
-          matTooltip="Delete user"
-        >
-          <mat-icon>delete</mat-icon>
-        </button>
+        <ng-container *gioPermission="{ anyOf: ['organization-user-d'] }">
+          <button
+            *ngIf="!element.primary_owner"
+            (click)="onDeleteUserClick(element)"
+            mat-icon-button
+            color="primary"
+            aria-label="Button to delete user"
+            matTooltip="Delete user"
+          >
+            <mat-icon>delete</mat-icon>
+          </button>
+        </ng-container>
       </td>
     </ng-container>
 

--- a/src/organization/configuration/users/org-settings-users.component.spec.ts
+++ b/src/organization/configuration/users/org-settings-users.component.spec.ts
@@ -27,11 +27,12 @@ import { MatInputHarness } from '@angular/material/input/testing';
 import { OrgSettingsUsersComponent } from './org-settings-users.component';
 
 import { OrganizationSettingsModule } from '../organization-settings.module';
-import { UIRouterStateParams, UIRouterState } from '../../../ajs-upgraded-providers';
+import { UIRouterStateParams, UIRouterState, CurrentUserService } from '../../../ajs-upgraded-providers';
 import { CONSTANTS_TESTING, GioHttpTestingModule } from '../../../shared/testing';
 import { User } from '../../../entities/user/user';
 import { fakePagedResult } from '../../../entities/pagedResult';
 import { fakeAdminUser } from '../../../entities/user/user.fixture';
+import { User as DeprecatedUser } from '../../../entities/user';
 
 describe('OrgSettingsUsersComponent', () => {
   let fixture: ComponentFixture<OrgSettingsUsersComponent>;
@@ -45,6 +46,7 @@ describe('OrgSettingsUsersComponent', () => {
       providers: [
         { provide: UIRouterState, useValue: { go: jest.fn() } },
         { provide: UIRouterStateParams, useValue: {} },
+        { provide: CurrentUserService, useValue: { currentUser: new DeprecatedUser() } },
       ],
     }).overrideProvider(InteractivityChecker, {
       useValue: {

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -26,6 +26,7 @@ import StringService from './string.service';
 
 import { PagedResult } from '../entities/pagedResult';
 import { User } from '../entities/user';
+import { UserDetails } from '../entities/user/userDetails';
 
 class UserService {
   /**
@@ -127,8 +128,8 @@ class UserService {
 
   current(): ng.IPromise<User> {
     if (!this.currentUser || !this.currentUser.authenticated) {
-      const promises: ng.IPromise<IHttpResponse<any>>[] = [
-        this.$http.get(`${this.Constants.org.baseURL}/user/`, {
+      const promises: ng.IPromise<IHttpResponse<unknown>>[] = [
+        this.$http.get<UserDetails>(`${this.Constants.org.baseURL}/user/`, {
           silentCall: true,
           forceSessionExpired: true,
         } as ng.IRequestShortcutConfig),
@@ -155,7 +156,7 @@ class UserService {
       return this.$q
         .all(promises)
         .then((response) => {
-          this.currentUser = Object.assign(new User(), response[0].data);
+          this.currentUser = Object.assign(new User(), response[0].data as UserDetails);
 
           this.currentUser.userPermissions = [];
           _.forEach(this.currentUser.roles, (role) => {

--- a/src/shared/components/gio-permission/gio-permission.directive.spec.ts
+++ b/src/shared/components/gio-permission/gio-permission.directive.spec.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { Component, Input } from '@angular/core';
+
+import { GioPermissionModule } from './gio-permission.module';
+import { GioPermissionCheckOptions } from './gio-permission.directive';
+
+import { CurrentUserService } from '../../../ajs-upgraded-providers';
+import { User } from '../../../entities/user';
+
+@Component({ template: `<div *gioPermission="permissions">A Content</div>` })
+class TestPermissionComponent {
+  @Input()
+  permissions: GioPermissionCheckOptions;
+}
+
+describe('GioPermissionDirective', () => {
+  let fixture: ComponentFixture<TestPermissionComponent>;
+  const currentUser = new User();
+  currentUser.userPermissions = [];
+  currentUser.userApiPermissions = [];
+  currentUser.userEnvironmentPermissions = [];
+  currentUser.userApplicationPermissions = [];
+
+  function prepareTestPermissionComponent(permission: GioPermissionCheckOptions) {
+    fixture = TestBed.configureTestingModule({
+      declarations: [TestPermissionComponent],
+      imports: [GioPermissionModule],
+      providers: [{ provide: CurrentUserService, useValue: { currentUser } }],
+    }).createComponent(TestPermissionComponent);
+
+    fixture.componentInstance.permissions = permission;
+    fixture.detectChanges();
+  }
+
+  afterEach(() => {
+    currentUser.userPermissions = [];
+    currentUser.userApiPermissions = [];
+    currentUser.userEnvironmentPermissions = [];
+    currentUser.userApplicationPermissions = [];
+  });
+
+  describe('anyOf', () => {
+    it('should hide element if permission is not matching', () => {
+      currentUser.userApiPermissions = ['api-rating-r', 'api-rating-c'];
+
+      prepareTestPermissionComponent({ anyOf: ['api-rating-u'] });
+      fixture.detectChanges();
+
+      const inputEl = fixture.nativeElement.querySelector('div');
+      expect(inputEl).toBeNull();
+    });
+
+    it('should display element if permission is matching', () => {
+      currentUser.userApiPermissions = ['api-rating-r', 'api-rating-c'];
+
+      prepareTestPermissionComponent({ anyOf: ['api-rating-r'] });
+      fixture.detectChanges();
+
+      const inputEl = fixture.nativeElement.querySelector('div');
+      expect(inputEl).toBeDefined();
+    });
+
+    it('should display element if at least one permission is matching', () => {
+      currentUser.userApiPermissions = ['api-rating-r', 'api-rating-c'];
+
+      prepareTestPermissionComponent({ anyOf: ['api-rating-r', 'api-rating-u'] });
+      fixture.detectChanges();
+
+      const inputEl = fixture.nativeElement.querySelector('div');
+      expect(inputEl).toBeDefined();
+    });
+  });
+
+  describe('noneOf', () => {
+    it('should hide element if no permission is matching', () => {
+      currentUser.userApiPermissions = ['api-rating-r', 'api-rating-c'];
+
+      prepareTestPermissionComponent({ noneOf: ['api-rating-u'] });
+      fixture.detectChanges();
+
+      const inputEl = fixture.nativeElement.querySelector('div');
+      expect(inputEl).toBeDefined();
+    });
+
+    it('should display element if a permission is matching', () => {
+      currentUser.userApiPermissions = ['api-rating-r', 'api-rating-c'];
+
+      prepareTestPermissionComponent({ noneOf: ['api-rating-r'] });
+      fixture.detectChanges();
+
+      const inputEl = fixture.nativeElement.querySelector('div');
+      expect(inputEl).toBeNull();
+    });
+
+    it('should display element if at least one permission is matching', () => {
+      currentUser.userApiPermissions = ['api-rating-r', 'api-rating-c'];
+
+      prepareTestPermissionComponent({ noneOf: ['api-rating-r', 'api-rating-u'] });
+      fixture.detectChanges();
+
+      const inputEl = fixture.nativeElement.querySelector('div');
+      expect(inputEl).toBeNull();
+    });
+  });
+});

--- a/src/shared/components/gio-permission/gio-permission.directive.ts
+++ b/src/shared/components/gio-permission/gio-permission.directive.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Directive, Input, OnInit, TemplateRef, ViewContainerRef } from '@angular/core';
+
+import { GioPermissionService } from './gio-permission.service';
+
+export interface GioPermissionCheckOptions {
+  anyOf?: string[];
+  noneOf?: string[];
+}
+
+@Directive({
+  selector: '[gioPermission]',
+})
+export class GioPermissionDirective implements OnInit {
+  @Input()
+  gioPermission: GioPermissionCheckOptions = {};
+
+  constructor(
+    private readonly permissionService: GioPermissionService,
+    private templateRef: TemplateRef<unknown>,
+    private viewContainer: ViewContainerRef,
+  ) {}
+
+  ngOnInit(): void {
+    if (this.gioPermission.anyOf && this.gioPermission.noneOf) {
+      throw new Error('You should only set `anyOf` or `noneOf` but not both at the same time.');
+    }
+
+    this.viewContainer.clear();
+
+    if (
+      (this.gioPermission.anyOf && this.permissionService.hasAnyMatching(this.gioPermission.anyOf)) ||
+      (this.gioPermission.noneOf && !this.permissionService.hasAnyMatching(this.gioPermission.noneOf))
+    ) {
+      this.viewContainer.createEmbeddedView(this.templateRef);
+    }
+  }
+}

--- a/src/shared/components/gio-permission/gio-permission.module.ts
+++ b/src/shared/components/gio-permission/gio-permission.module.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { GioPermissionDirective } from './gio-permission.directive';
+import { GioPermissionService } from './gio-permission.service';
+
+@NgModule({
+  imports: [CommonModule],
+  declarations: [GioPermissionDirective],
+  exports: [GioPermissionDirective],
+  providers: [GioPermissionService],
+})
+export class GioPermissionModule {}

--- a/src/shared/components/gio-permission/gio-permission.service.ts
+++ b/src/shared/components/gio-permission/gio-permission.service.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Inject, Injectable } from '@angular/core';
+import { intersection } from 'lodash';
+
+import UserService from '../../../services/user.service';
+import { CurrentUserService } from '../../../ajs-upgraded-providers';
+import { User } from '../../../entities/user';
+
+@Injectable({ providedIn: 'root' })
+export class GioPermissionService {
+  public readonly currentUser: User;
+
+  constructor(@Inject(CurrentUserService) private readonly currentUserService: UserService) {
+    this.currentUser = currentUserService.currentUser;
+  }
+
+  hasAnyMatching(permissions: string[]): boolean {
+    if (!permissions || !this.currentUser.userPermissions) {
+      return false;
+    }
+    return (
+      intersection(this.currentUser.userPermissions, permissions).length > 0 ||
+      intersection(this.currentUser.userEnvironmentPermissions, permissions).length > 0 ||
+      intersection(this.currentUser.userApiPermissions, permissions).length > 0 ||
+      intersection(this.currentUser.userApplicationPermissions, permissions).length > 0
+    );
+  }
+}


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6204

**Description**

- Introduce a GioPermission directive to hide/show an element according to a certain set of permissions.
It currently relies on the currentUser from UserService. The end goal is to reverse the dependency and make the RoleService use the GioPermission one.

 - Use Permission directive in Users Org Settings screen
