### PR TITLE
Migration Identity Providers settings screen

### DIFF
--- a/src/organization/configuration/identity-providers/org-settings-identity-providers.component.html
+++ b/src/organization/configuration/identity-providers/org-settings-identity-providers.component.html
@@ -119,17 +119,19 @@
       <th mat-header-cell *matHeaderCellDef id="actions"></th>
       <td mat-cell *matCellDef="let element">
         <div class="org-settings-identity-providers__table__centered-cell">
-          <button
-            (click)="onActivationToggleActionClicked(element)"
-            mat-icon-button
-            color="primary"
-            aria-label="Switch to toggle an identity provider activation"
-            matTooltip="
+          <ng-container *gioPermission="{ anyOf: ['organization-identity_provider_activation-u'] }">
+            <button
+              (click)="onActivationToggleActionClicked(element)"
+              mat-icon-button
+              color="primary"
+              aria-label="Switch to toggle an identity provider activation"
+              matTooltip="
             {{ element.activated ? 'Deactivate identity provider' : 'Activate identity provider' }}
             "
-          >
-            <mat-icon>{{ element.activated ? 'toggle_off' : 'toggle_on' }}</mat-icon>
-          </button>
+            >
+              <mat-icon>{{ element.activated ? 'toggle_off' : 'toggle_on' }}</mat-icon>
+            </button>
+          </ng-container>
           <button
             (click)="onEditActionClicked(element)"
             mat-icon-button

--- a/src/organization/configuration/identity-providers/org-settings-identity-providers.component.html
+++ b/src/organization/configuration/identity-providers/org-settings-identity-providers.component.html
@@ -139,15 +139,17 @@
           >
             <mat-icon>edit</mat-icon>
           </button>
-          <button
-            (click)="onDeleteActionClicked(element)"
-            mat-icon-button
-            color="primary"
-            aria-label="Button to delete an identity provider"
-            matTooltip="Delete identity provider"
-          >
-            <mat-icon>delete</mat-icon>
-          </button>
+          <ng-container *gioPermission="{ anyOf: ['organization-identity_provider-d'] }">
+            <button
+              (click)="onDeleteActionClicked(element)"
+              mat-icon-button
+              color="primary"
+              aria-label="Button to delete an identity provider"
+              matTooltip="Delete identity provider"
+            >
+              <mat-icon>delete</mat-icon>
+            </button>
+          </ng-container>
         </div>
       </td>
     </ng-container>

--- a/src/organization/configuration/identity-providers/org-settings-identity-providers.component.html
+++ b/src/organization/configuration/identity-providers/org-settings-identity-providers.component.html
@@ -34,7 +34,10 @@
   </mat-slide-toggle>
 </div>
 
-<h2>Identity Providers</h2>
+<div class="org-settings-identity-providers__search-bar">
+  <h2>Identity Providers</h2>
+  <button (click)="onAddIdpClicked()" mat-raised-button color="primary"><mat-icon>add</mat-icon>Add an identity provider</button>
+</div>
 <div class="mat-elevation-z2">
   <table
     mat-table

--- a/src/organization/configuration/identity-providers/org-settings-identity-providers.component.html
+++ b/src/organization/configuration/identity-providers/org-settings-identity-providers.component.html
@@ -54,7 +54,7 @@
     <!-- Id Column -->
     <ng-container matColumnDef="id">
       <th mat-header-cell *matHeaderCellDef id="id">Id</th>
-      <td mat-cell *matCellDef="let element" (click)="onIdClicked(element)">
+      <td mat-cell *matCellDef="let element" (click)="onEditActionClicked(element)">
         <a>{{ element.id }}</a>
       </td>
     </ng-container>

--- a/src/organization/configuration/identity-providers/org-settings-identity-providers.component.scss
+++ b/src/organization/configuration/identity-providers/org-settings-identity-providers.component.scss
@@ -65,6 +65,14 @@
     margin-bottom: 16px;
   }
 
+  &__search-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    // Magic value to have proper alignment and consistent visual experience with users screen
+    height: 70px;
+  }
+
   &__configuration {
     width: 30%;
     min-width: 400px;

--- a/src/organization/configuration/identity-providers/org-settings-identity-providers.component.scss
+++ b/src/organization/configuration/identity-providers/org-settings-identity-providers.component.scss
@@ -25,6 +25,10 @@
   width: 10%;
 }
 
+.mat-cell.mat-column-id {
+  cursor: pointer;
+}
+
 .mat-column-name {
   width: 14%;
 }

--- a/src/organization/configuration/identity-providers/org-settings-identity-providers.component.spec.ts
+++ b/src/organization/configuration/identity-providers/org-settings-identity-providers.component.spec.ts
@@ -20,23 +20,48 @@ import { HarnessLoader } from '@angular/cdk/testing';
 import { HttpTestingController } from '@angular/common/http/testing';
 import { InteractivityChecker } from '@angular/cdk/a11y';
 import { MatSlideToggleHarness } from '@angular/material/slide-toggle/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
 
 import { OrgSettingsIdentityProvidersComponent } from './org-settings-identity-providers.component';
 
 import { OrganizationSettingsModule } from '../organization-settings.module';
 import { CONSTANTS_TESTING, GioHttpTestingModule } from '../../../shared/testing';
 import { ConsoleSettings } from '../../../entities/consoleSettings';
-import { fakeIdentityProviderListItem } from '../../../entities/identity-provider/identityProviderListItem.fixture';
-import { fakeIdentityProviderActivation } from '../../../entities/identity-provider';
+import {
+  fakeIdentityProviderListItem,
+  fakeIdentityProviderActivation,
+  IdentityProviderActivation,
+  IdentityProviderListItem,
+} from '../../../entities/identity-provider';
+import { CurrentUserService, UIRouterState } from '../../../ajs-upgraded-providers';
+import { User } from '../../../entities/user';
 
 describe('OrgSettingsIdentityProvidersComponent', () => {
+  const currentUser = new User();
+  currentUser.userPermissions = [];
+  currentUser.userApiPermissions = [];
+  currentUser.userEnvironmentPermissions = [];
+  currentUser.userApplicationPermissions = [];
+
   let fixture: ComponentFixture<OrgSettingsIdentityProvidersComponent>;
   let loader: HarnessLoader;
+  let rootLoader: HarnessLoader;
+
   let httpTestingController: HttpTestingController;
+  const fake$State = {
+    go: jest.fn(),
+  };
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [NoopAnimationsModule, OrganizationSettingsModule, GioHttpTestingModule],
+      providers: [
+        { provide: UIRouterState, useValue: fake$State },
+        {
+          provide: CurrentUserService,
+          useValue: { currentUser },
+        },
+      ],
     }).overrideProvider(InteractivityChecker, {
       useValue: {
         isFocusable: () => true, // This checks focus trap, set it to true to  avoid the warning
@@ -46,25 +71,13 @@ describe('OrgSettingsIdentityProvidersComponent', () => {
     httpTestingController = TestBed.inject(HttpTestingController);
     fixture = TestBed.createComponent(OrgSettingsIdentityProvidersComponent);
     loader = TestbedHarnessEnvironment.loader(fixture);
-    fixture.detectChanges();
+    rootLoader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+
     fixture.detectChanges();
   });
 
   afterEach(() => {
     httpTestingController.verify();
-  });
-
-  it('should createComponent', () => {
-    const consoleSettings: ConsoleSettings = {
-      authentication: {
-        localLogin: { enabled: true },
-      },
-    };
-    httpTestingController.expectOne(`${CONSTANTS_TESTING.org.baseURL}/settings`).flush(consoleSettings);
-    httpTestingController.expectOne(`${CONSTANTS_TESTING.org.baseURL}/identities`).flush([fakeIdentityProviderActivation()]);
-    httpTestingController.expectOne(`${CONSTANTS_TESTING.org.baseURL}/configuration/identities`).flush([]);
-
-    expect(fixture.componentInstance).toBeDefined();
   });
 
   it('update console settings with toggling the input', async () => {
@@ -73,14 +86,16 @@ describe('OrgSettingsIdentityProvidersComponent', () => {
         localLogin: { enabled: true },
       },
     };
-    httpTestingController.expectOne(`${CONSTANTS_TESTING.org.baseURL}/settings`).flush(consoleSettings);
 
-    httpTestingController.expectOne(`${CONSTANTS_TESTING.org.baseURL}/identities`).flush([fakeIdentityProviderActivation()]);
-    httpTestingController.expectOne(`${CONSTANTS_TESTING.org.baseURL}/configuration/identities`).flush([
-      fakeIdentityProviderListItem({
-        enabled: true,
-      }),
-    ]);
+    flushResponseToInitialRequests(
+      consoleSettings,
+      [
+        fakeIdentityProviderListItem({
+          enabled: true,
+        }),
+      ],
+      [fakeIdentityProviderActivation()],
+    );
 
     const activateLoginSlideToggle = await loader.getHarness(
       MatSlideToggleHarness.with({ label: 'Show login form on management console' }),
@@ -98,4 +113,55 @@ describe('OrgSettingsIdentityProvidersComponent', () => {
     expect(req.request.body).toMatchObject(expectedConsoleSettings);
     req.flush(expectedConsoleSettings);
   });
+
+  describe('onDeleteActionClicked', () => {
+    beforeEach(() => {
+      currentUser.userPermissions = ['organization-identity_provider-d'];
+    });
+
+    it('sends a DELETE request', async () => {
+      const consoleSettings: ConsoleSettings = {
+        authentication: {
+          localLogin: { enabled: true },
+        },
+      };
+
+      flushResponseToInitialRequests(
+        consoleSettings,
+        [
+          fakeIdentityProviderListItem({
+            id: 'google',
+          }),
+        ],
+        [
+          fakeIdentityProviderActivation({
+            identityProvider: 'google',
+          }),
+        ],
+      );
+
+      const activateLoginSlideToggle = await loader.getHarness(
+        MatButtonHarness.with({ selector: '[aria-label="Button to delete an identity provider"]' }),
+      );
+      await activateLoginSlideToggle.click();
+
+      // Use rootLoader to find the Remove button inside the dialog
+      const confirmDialogButton = await rootLoader.getHarness(MatButtonHarness.with({ text: 'Remove' }));
+      await confirmDialogButton.click();
+
+      httpTestingController.expectOne(`${CONSTANTS_TESTING.org.baseURL}/configuration/identities/google`).flush(null);
+
+      flushResponseToInitialRequests(consoleSettings, [], []);
+    });
+  });
+
+  function flushResponseToInitialRequests(
+    consoleSettings: ConsoleSettings,
+    identityProviderListItem: IdentityProviderListItem[],
+    activatedIdentityProviders: IdentityProviderActivation[],
+  ) {
+    httpTestingController.expectOne(`${CONSTANTS_TESTING.org.baseURL}/settings`).flush(consoleSettings);
+    httpTestingController.expectOne(`${CONSTANTS_TESTING.org.baseURL}/configuration/identities`).flush(identityProviderListItem);
+    httpTestingController.expectOne(`${CONSTANTS_TESTING.org.baseURL}/identities`).flush(activatedIdentityProviders);
+  }
 });

--- a/src/organization/configuration/identity-providers/org-settings-identity-providers.component.spec.ts
+++ b/src/organization/configuration/identity-providers/org-settings-identity-providers.component.spec.ts
@@ -155,6 +155,37 @@ describe('OrgSettingsIdentityProvidersComponent', () => {
     });
   });
 
+  describe('onEditActionClicked', () => {
+    it('triggers AngularJS router', async () => {
+      const consoleSettings: ConsoleSettings = {
+        authentication: {
+          localLogin: { enabled: true },
+        },
+      };
+
+      flushResponseToInitialRequests(
+        consoleSettings,
+        [
+          fakeIdentityProviderListItem({
+            id: 'google',
+          }),
+        ],
+        [
+          fakeIdentityProviderActivation({
+            identityProvider: 'google',
+          }),
+        ],
+      );
+
+      const activateLoginSlideToggle = await loader.getHarness(
+        MatButtonHarness.with({ selector: '[aria-label="Button to edit an identity provider"]' }),
+      );
+      await activateLoginSlideToggle.click();
+
+      expect(fake$State.go).toHaveBeenCalledWith('organization.settings.identityproviders.identityprovider', { id: 'google' });
+    });
+  });
+
   function flushResponseToInitialRequests(
     consoleSettings: ConsoleSettings,
     identityProviderListItem: IdentityProviderListItem[],

--- a/src/organization/configuration/identity-providers/org-settings-identity-providers.component.spec.ts
+++ b/src/organization/configuration/identity-providers/org-settings-identity-providers.component.spec.ts
@@ -182,6 +182,35 @@ describe('OrgSettingsIdentityProvidersComponent', () => {
     });
   });
 
+  describe('onAddIdpClicked', () => {
+    it('triggers AngularJS router', async () => {
+      const consoleSettings: ConsoleSettings = {
+        authentication: {
+          localLogin: { enabled: true },
+        },
+      };
+
+      flushResponseToInitialRequests(
+        consoleSettings,
+        [
+          fakeIdentityProviderListItem({
+            id: 'gravitee-am',
+          }),
+        ],
+        [
+          fakeIdentityProviderActivation({
+            identityProvider: 'gravitee-am',
+          }),
+        ],
+      );
+
+      const activateLoginSlideToggle = await loader.getHarness(MatButtonHarness.with({ text: /Add an identity provider/ }));
+      await activateLoginSlideToggle.click();
+
+      expect(fake$State.go).toHaveBeenCalledWith('organization.settings.ng-identityprovider');
+    });
+  });
+
   describe('onActivationToggleActionClicked', () => {
     beforeEach(() => {
       currentUser.userPermissions = ['organization-identity_provider_activation-u'];

--- a/src/organization/configuration/identity-providers/org-settings-identity-providers.component.ts
+++ b/src/organization/configuration/identity-providers/org-settings-identity-providers.component.ts
@@ -201,4 +201,8 @@ export class OrgSettingsIdentityProvidersComponent implements OnInit, OnDestroy 
     }
     return null;
   }
+
+  onAddIdpClicked(): void {
+    this.$state.go('organization.settings.ng-identityprovider');
+  }
 }

--- a/src/services-ngx/identity-provider.service.spec.ts
+++ b/src/services-ngx/identity-provider.service.spec.ts
@@ -20,6 +20,7 @@ import { IdentityProviderService } from './identity-provider.service';
 
 import { CONSTANTS_TESTING, GioHttpTestingModule } from '../shared/testing';
 import { fakeIdentityProviderListItem } from '../entities/identity-provider/identityProviderListItem.fixture';
+import { IdentityProviderListItem } from '../entities/identity-provider';
 
 describe('IdentityProviderService', () => {
   let httpTestingController: HttpTestingController;
@@ -36,9 +37,9 @@ describe('IdentityProviderService', () => {
 
   describe('list', () => {
     it('should return a list of identity providers', (done) => {
-      const identityProviders = [
+      const identityProviders: IdentityProviderListItem[] = [
         fakeIdentityProviderListItem({ id: 'google', type: 'GOOGLE' }),
-        [fakeIdentityProviderListItem({ id: 'github', type: 'GITHUB' })],
+        fakeIdentityProviderListItem({ id: 'github', type: 'GITHUB' }),
       ];
 
       identityProviderService.list().subscribe((identityProviders) => {
@@ -50,6 +51,24 @@ describe('IdentityProviderService', () => {
       expect(req.request.method).toEqual('GET');
 
       req.flush(identityProviders);
+    });
+  });
+
+  describe('delete', () => {
+    it('should send a DELETE request', (done) => {
+      const identityProviderToDelete: IdentityProviderListItem = fakeIdentityProviderListItem({ id: 'github', type: 'GITHUB' });
+
+      identityProviderService.delete(identityProviderToDelete.id).subscribe((identityProviders) => {
+        expect(identityProviders).toEqual(identityProviders);
+        done();
+      });
+
+      const req = httpTestingController.expectOne(
+        `${CONSTANTS_TESTING.org.baseURL}/configuration/identities/${identityProviderToDelete.id}`,
+      );
+      expect(req.request.method).toEqual('DELETE');
+
+      req.flush(null);
     });
   });
 

--- a/src/services-ngx/identity-provider.service.ts
+++ b/src/services-ngx/identity-provider.service.ts
@@ -18,7 +18,7 @@ import { Inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 
 import { Constants } from '../entities/Constants';
-import { IdentityProviderListItem } from '../entities/identity-provider/identityProviderListItem';
+import { IdentityProviderListItem } from '../entities/identity-provider';
 
 @Injectable({
   providedIn: 'root',
@@ -28,5 +28,9 @@ export class IdentityProviderService {
 
   list(): Observable<IdentityProviderListItem[]> {
     return this.http.get<IdentityProviderListItem[]>(`${this.constants.org.baseURL}/configuration/identities`);
+  }
+
+  delete(idpId: string): Observable<void> {
+    return this.http.delete<void>(`${this.constants.org.baseURL}/configuration/identities/${idpId}`);
   }
 }

--- a/src/services-ngx/organization.service.spec.ts
+++ b/src/services-ngx/organization.service.spec.ts
@@ -53,6 +53,22 @@ describe('OrganizationService', () => {
     });
   });
 
+  describe('updateActivatedIdentityProviders', () => {
+    it('should send identity providers to activate', (done) => {
+      identityProviderService
+        .updateActivatedIdentityProviders([{ identityProvider: 'google' }, { identityProvider: 'github' }])
+        .subscribe(() => {
+          done();
+        });
+
+      const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.org.baseURL}/identities`);
+      expect(req.request.method).toEqual('PUT');
+      expect(req.request.body).toEqual([{ identityProvider: 'google' }, { identityProvider: 'github' }]);
+
+      req.flush(null);
+    });
+  });
+
   afterEach(() => {
     httpTestingController.verify();
   });

--- a/src/services-ngx/organization.service.ts
+++ b/src/services-ngx/organization.service.ts
@@ -29,4 +29,8 @@ export class OrganizationService {
   listActivatedIdentityProviders(): Observable<IdentityProviderActivation[]> {
     return this.http.get<IdentityProviderActivation[]>(`${this.constants.org.baseURL}/identities`);
   }
+
+  updateActivatedIdentityProviders(idpsToActivate: { identityProvider: string }[]): Observable<void> {
+    return this.http.put<void>(`${this.constants.org.baseURL}/identities`, idpsToActivate);
+  }
 }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6058

**Description**

To review and merge after https://github.com/gravitee-io/gravitee-management-webui/pull/1711

Add interaction to: 
 - Activate/Deactivate an identity provider
 - Delete an identity provider
 - Go to the detail screen of an identity provider

**Screenshots**

https://user-images.githubusercontent.com/4112568/135093448-dbfbc41f-8d34-4806-9159-35775b0c88bf.mp4
