### PR TITLE
fix: fix top failed widget analytics query

### DIFF
--- a/src/components/widget/widget.component.ts
+++ b/src/components/widget/widget.component.ts
@@ -53,7 +53,6 @@ const WidgetComponent: ng.IComponentOptions = {
 
     let unregisterFn = $scope.$on('onQueryFilterChange', (event, query) => {
       if (this.widget.chart && this.widget.chart.request) {
-        this.widget.chart.request.query = query.query;
         this.reload();
       }
     });
@@ -78,8 +77,14 @@ const WidgetComponent: ng.IComponentOptions = {
         } else {
           filters = Object.keys(queryFilters);
         }
-        chartRequest.query = filters
-          .map((f) => '(' + f + ':' + queryFilters[f].map((qp) => this.AnalyticsService.buildQueryParam(qp, f)).join(' OR ') + ')')
+
+        chartRequest.query = [
+          // Specific initial query or empty string
+          chartRequest.query,
+          filters.map((f) => `(${f}:${queryFilters[f].map((qp) => this.AnalyticsService.buildQueryParam(qp, f)).join(' OR ')})`),
+        ]
+          .reduce((acc, val) => acc.concat(val), [])
+          .filter((part) => part)
           .join(' AND ');
       }
 


### PR DESCRIPTION
https://github.com/gravitee-io/issues/issues/5771

fix: fix top failed widget analytics query

Add widget specific query at the end of the chart request query built from dashboard filters.
For example, for top failed widget, it will add the "status:[500 TO 599]" at the end of the generated query.
